### PR TITLE
highlight recent actions

### DIFF
--- a/engine/src/available-command.ts
+++ b/engine/src/available-command.ts
@@ -349,7 +349,7 @@ export function possibleBoardActions(engine: Engine, player: Player) {
   const commands = [];
 
   let poweracts = BoardAction.values(Expansion.All).filter(
-    (pwract) => engine.boardActions[pwract] && engine.player(player).canPay(Reward.parse(boardActions[pwract].cost))
+    (pwract) => !engine.boardActions[pwract] && engine.player(player).canPay(Reward.parse(boardActions[pwract].cost))
   );
 
   // Prevent using the rescore action if no federation token

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -109,7 +109,7 @@ export default class Engine {
     federations: {},
   };
   boardActions: {
-    [key in BoardAction]?: boolean;
+    [key in BoardAction]?: PlayerEnum;
   } = {};
 
   terraformingFederation: Federation;
@@ -559,7 +559,6 @@ export default class Engine {
       if (key === "map" || key === "players" || Object.getOwnPropertyDescriptor(Engine.prototype, key)?.get) {
         continue;
       }
-
       engine[key] = data[key];
     }
 
@@ -581,6 +580,15 @@ export default class Engine {
         for (const player of hex.occupyingPlayers()) {
           engine.player(player).data.occupied.push(hex);
         }
+      }
+    }
+
+    // LEGACY CODE
+    // TODO: Remove when games are updated (also remove player !== Player.Player5)
+    for (const key of Object.keys(engine.boardActions)) {
+      const action = engine.boardActions[key];
+      if (typeof action == "boolean") {
+        engine.boardActions[key] = action ? null : PlayerEnum.Player5;
       }
     }
 
@@ -962,7 +970,7 @@ export default class Engine {
     }
     // resets power and qic actions
     BoardAction.values(this.expansions).forEach((pos: BoardAction) => {
-      this.boardActions[pos] = true;
+      this.boardActions[pos] = null;
     });
 
     if (this.isLastRound) {
@@ -1295,7 +1303,7 @@ export default class Engine {
 
     // powerActions
     BoardAction.values(this.expansions).forEach((pos: BoardAction) => {
-      this.boardActions[pos] = true;
+      this.boardActions[pos] = null;
     });
 
     const feds = Federation.values();
@@ -1603,7 +1611,7 @@ export default class Engine {
     );
 
     const pl = this.player(player);
-    this.boardActions[action] = false;
+    this.boardActions[action] = player;
 
     pl.payCosts(Reward.parse(boardActions[action].cost), action);
     pl.loadEvents(Event.parse(boardActions[action].income, action));

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "lint-staged": "lint-staged",
     "postinstall": "husky install",
+    "prettier": "prettier --plugin-search-dir=. --write .",
     "prettier-check": "prettier --plugin-search-dir=. --check ."
   },
   "devDependencies": {

--- a/viewer/src/components/AdvancedLog.vue
+++ b/viewer/src/components/AdvancedLog.vue
@@ -44,7 +44,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
-import Engine, { LogEntry } from "@gaia-project/engine";
+import { LogEntry } from "@gaia-project/engine";
 
 @Component({
   computed: {

--- a/viewer/src/components/BoardAction.vue
+++ b/viewer/src/components/BoardAction.vue
@@ -2,6 +2,7 @@
   <g :class="['boardAction', kind, { highlighted }]" v-b-tooltip :title="tooltip">
     <SpecialAction
       :class="{ faded }"
+      :planet="planet"
       :action="boardActions[action].income"
       :highlighted="highlighted"
       :board="true"
@@ -39,9 +40,17 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
-import { tiles, Event, BoardAction as BoardActionEnum, boardActions, Reward } from "@gaia-project/engine";
-import { eventDesc } from "../data/event";
+import {Component, Prop} from "vue-property-decorator";
+import {
+  BoardAction as BoardActionEnum,
+  boardActions,
+  Event,
+  factions,
+  Planet,
+  PlayerEnum,
+  Reward
+} from "@gaia-project/engine";
+import {eventDesc} from "../data/event";
 import Resource from "./Resource.vue";
 import SpecialAction from "./SpecialAction.vue";
 
@@ -73,7 +82,16 @@ export default class BoardAction extends Vue {
   }
 
   get faded() {
-    return !this.$store.state.gaiaViewer.data.boardActions[this.action];
+    return this.planet != null;
+  }
+
+  get planet(): Planet {
+    const data = this.$store.state.gaiaViewer.data;
+    const player = data.boardActions[this.action];
+    if (player != null && player !== PlayerEnum.Player5) { // Player5 is for converted old games
+      return factions.planet(data.player(player).faction);
+    }
+    return null;
   }
 
   get kind() {

--- a/viewer/src/components/SpaceHex.vue
+++ b/viewer/src/components/SpaceHex.vue
@@ -12,6 +12,8 @@
         {
           toSelect,
           highlighted: highlightedHexes.has(hex),
+          recent: recent(hex),
+          'current-round': currentRound(hex),
           qic: cost(hex).includes('q'),
           power: cost(hex).includes('pw'),
         },
@@ -52,20 +54,19 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import {Component, Prop} from "vue-property-decorator";
 import {
-  GaiaHex,
-  factions,
   Building as BuildingEnum,
+  factions,
+  GaiaHex,
   Planet as PlanetEnum,
   SpaceMap as ISpaceMap,
-  Faction,
 } from "@gaia-project/engine";
-import { corners } from "../graphics/hex";
+import {corners} from "../graphics/hex";
 import Planet from "./Planet.vue";
 import Building from "./Building.vue";
-import { buildingName } from "../data/building";
-import { planetNames } from "../data/planets";
+import {buildingName} from "../data/building";
+import {planetNames} from "../data/planets";
 
 @Component<SpaceHex>({
   components: {
@@ -127,13 +128,27 @@ export default class SpaceHex extends Vue {
     return this.$store.state.gaiaViewer.context.highlighted.hexes;
   }
 
+  recent(hex: GaiaHex): boolean {
+    return this.$store.getters["gaiaViewer/recentHexes"].includes(hex);
+  }
+
+  currentRound(hex: GaiaHex): boolean {
+    return this.$store.getters["gaiaViewer/currentRoundHexes"].includes(hex);
+  }
+
   get toSelect() {
-    return !!this.$store.state.gaiaViewer.context.hexSelection;
+    return !!this.context().hexSelection;
+  }
+
+  private context() {
+    return this.$store.state.gaiaViewer.context;
   }
 }
 </script>
 
 <style lang="scss">
+@import "../stylesheets/planets.scss";
+
 svg {
   .spaceHex {
     fill: #172e62;
@@ -155,6 +170,14 @@ svg {
       &.power {
         fill: #d378d3;
       }
+    }
+
+    &.current-round:not(.highlighted):not(.toSelect) {
+      fill: $current-round;
+    }
+
+    &.recent:not(.highlighted):not(.toSelect) {
+      fill: $recent;
     }
 
     &.toSelect {

--- a/viewer/src/components/SpecialAction.vue
+++ b/viewer/src/components/SpecialAction.vue
@@ -1,7 +1,12 @@
 <template>
   <svg viewBox="-25 -25 50 50" width="50" height="50" style="overflow: visible">
     <g :class="['specialAction', { highlighted: isHighlighted, disabled, board }]">
-      <polygon points="-10,4 -4,10 4,10 10,4 10,-4 4,-10 -4,-10 -10,-4" transform="scale(2.4)" @click="onClick" />
+      <polygon
+        points="-10,4 -4,10 4,10 10,4 10,-4 4,-10 -4,-10 -10,-4"
+        transform="scale(2.4)"
+        @click="onClick"
+        :class="`${planet != null ? 'planet-fill ' + planet : ''}`"
+      />
       <!-- <Resource v-for="(reward, i) in rewards" :key=i :count=reward.count :kind=reward.type :transform="`translate(${rewards.length > 1 ? (i - 0.5) * 20  : 0}, ${reward.type === 'pw' ? 4 : 0}), scale(1.5)`" />-->
       <TechContent
         :content="act"
@@ -20,8 +25,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
-import { tiles, Event, Reward } from "@gaia-project/engine";
-import { eventDesc } from "../data/event";
+import { Event, Planet } from "@gaia-project/engine";
 
 @Component
 export default class SpecialAction extends Vue {
@@ -36,6 +40,9 @@ export default class SpecialAction extends Vue {
 
   @Prop()
   action: string[];
+
+  @Prop()
+  planet: Planet;
 
   onClick() {
     if (!this._highlighted) {
@@ -74,7 +81,7 @@ g {
       fill: $specialAction;
     }
 
-    &.board > polygon {
+    &.board > polygon:not(.planet-fill) {
       fill: $systemGray6;
     }
 

--- a/viewer/src/logic/recent.spec.ts
+++ b/viewer/src/logic/recent.spec.ts
@@ -1,0 +1,99 @@
+import { LogEntry, PlayerEnum } from "@gaia-project/engine";
+import { expect } from "chai";
+import { recentMoves } from "./recent";
+
+describe("Moves", () => {
+  describe("recentMoves", () => {
+    const tests: {
+      name: string;
+      give: { moveHistory: string[]; logEntries: LogEntry[] };
+      want: string[];
+    }[] = [
+      {
+        name: "player starts",
+        give: {
+          moveHistory: [
+            "init 2 randomSeed2",
+            "p2 rotate",
+            "p1 faction terrans",
+            "p2 faction geodens",
+            "terrans build m 8A2",
+          ],
+          logEntries: [
+            { player: 1, move: 1 },
+            { player: 0, move: 2 },
+            { player: 1, move: 3 },
+            { player: 0 },
+            { player: 1 },
+            { player: 0, move: 4 },
+          ],
+        },
+        want: ["terrans build m 8A2"],
+      },
+      {
+        name: "player is about to place second mine",
+        give: {
+          moveHistory: [
+            "init 2 randomSeed2",
+            "p2 rotate",
+            "p1 faction terrans",
+            "p2 faction geodens",
+            "terrans build m 8A2",
+            "geodens build m 1A5",
+          ],
+          logEntries: [
+            { player: 1, move: 1 },
+            { player: 0, move: 2 },
+            { player: 1, move: 3 },
+            { player: 0 },
+            { player: 1 },
+            { player: 0, move: 4 },
+            { player: 1, move: 5 },
+          ],
+        },
+        want: ["terrans build m 8A2"],
+      },
+      {
+        name: "ignores charge and brainstone",
+        give: {
+          moveHistory: [
+            "init 2 randomSeed2",
+            "p2 rotate",
+            "p1 faction firaks",
+            "p2 faction taklons",
+            "firaks build m 7A0",
+            "taklons build m 2B3",
+            "taklons build m 4B3",
+            "firaks build m 4A10",
+            "taklons booster booster1",
+            "firaks booster booster3",
+            "firaks build ts 7A0.",
+            "taklons charge 1pw. brainstone area1",
+          ],
+          logEntries: [
+            { player: 1, move: 1 },
+            { player: 0, move: 2 },
+            { player: 1, move: 3 },
+            { player: 0, move: 4 },
+            { player: 1, move: 5 },
+            { player: 1, move: 6 },
+            { player: 0, move: 7 },
+            { player: 1, move: 8 },
+            { player: 0, move: 9 },
+            { player: 0, move: 10 },
+            { player: 1, move: 11 },
+            { player: 1, move: 12 },
+          ],
+        },
+        want: ["firaks booster booster3", "firaks build ts 7A0."],
+      },
+    ];
+
+    for (const test of tests) {
+      it(test.name, () => {
+        const moves = recentMoves(PlayerEnum.Player2, test.give.logEntries, test.give.moveHistory);
+        expect(moves).to.deep.equal(test.want);
+      });
+    }
+  });
+});

--- a/viewer/src/logic/recent.ts
+++ b/viewer/src/logic/recent.ts
@@ -1,0 +1,47 @@
+import Engine, { Command, GaiaHex, LogEntry, PlayerEnum } from "@gaia-project/engine";
+import { findLast, findLastIndex } from "lodash";
+
+export function movesToHexes(data: Engine, moves: string[]): GaiaHex[] {
+  return moves.flatMap((move) => {
+    const args = data.parseMove(move).args;
+    const number = args.indexOf("build");
+    if (number >= 0) {
+      const coord = args[number + 2].replace(".", "");
+      const hex = data.map.getS(coord);
+      return [hex];
+    }
+    return [];
+  });
+}
+
+function ownTurn(move: string): boolean {
+  if (move == null) {
+    return false;
+  }
+  const outOfTurn = [Command.ChargePower, Command.BrainStone, Command.ChooseIncome, Command.Decline];
+  return !outOfTurn.some((command) => move.includes(command));
+}
+
+export function recentMoves(player: PlayerEnum, logEntries: LogEntry[], moveHistory: string[]) {
+  let last = logEntries.length;
+  let lastMove = moveHistory.length;
+  while (last > 0 && logEntries[last - 1].player === player) {
+    const move = logEntries[last - 1].move;
+    if (move) {
+      lastMove = move;
+    }
+    last--;
+  }
+
+  const firstMove = findLast(
+    logEntries.slice(0, last),
+    (logItem) => logItem.player === player && ownTurn(moveHistory[logItem.move])
+  )?.move;
+  return firstMove ? moveHistory.slice(firstMove + 1, lastMove) : [];
+}
+
+export function roundMoves(logEntries: LogEntry[], moveHistory: string[]) {
+  const roundEntryIndex = findLastIndex(logEntries, (logItem) => "round" in logItem);
+  const moveIndex = logEntries.slice(roundEntryIndex + 1).find((logItem) => !!logItem.move)?.move;
+  return moveIndex ? moveHistory.slice(moveIndex) : [];
+}

--- a/viewer/src/store.ts
+++ b/viewer/src/store.ts
@@ -11,6 +11,7 @@ import { CubeCoordinates } from "hexagrid";
 import Vue from "vue";
 import Vuex from "vuex";
 import { GameContext } from "./data";
+import { movesToHexes, recentMoves, roundMoves } from "./logic/recent";
 
 Vue.use(Vuex);
 
@@ -35,6 +36,7 @@ const gaiaViewer = {
       accessibleSpaceMap: false,
       noFactionFill: false,
       flatBuildings: false,
+      highlightRecentActions: false,
     },
     player: null as { index?: number; auth?: string } | null,
   },
@@ -125,7 +127,23 @@ const gaiaViewer = {
     // WRAPPER / DEBUG COMMUNICATION
     loadFromJSON(context, data: any) {},
   },
-  getters: {},
+  getters: {
+    currentRoundHexes: (state): GaiaHex[] => {
+      if (state.preferences.highlightRecentActions) {
+        const data = state.data;
+        return movesToHexes(data, roundMoves(data.advancedLog, data.moveHistory));
+      }
+      return [];
+    },
+    recentHexes: (state): GaiaHex[] => {
+      if (state.preferences.highlightRecentActions) {
+        const data = state.data;
+        const player = state.player?.index ?? data.currentPlayer;
+        return movesToHexes(data, recentMoves(player, data.advancedLog, data.moveHistory));
+      }
+      return [];
+    },
+  },
 };
 
 function makeStore() {

--- a/viewer/src/stylesheets/planets.scss
+++ b/viewer/src/stylesheets/planets.scss
@@ -44,3 +44,6 @@ $systemGray3: #c7c7cc;
 $systemGray4: #d1d1d6;
 $systemGray5: #e5e5ea;
 $systemGray6: #f2f2f7;
+
+$recent: gold;
+$current-round: black;


### PR DESCRIPTION
Highlight (enabled by `highlightRecentActions` preference)
- hexes that were settled since last turn in gold
- hexes that were settled since this round in black

It doesn't work perfect yet - sometimes it's not highlighted.

![space_ma](https://user-images.githubusercontent.com/2832627/108603002-9dd96400-73a5-11eb-90a9-f69fbb7bee15.png)

Show which player took a board action

![board_action](https://user-images.githubusercontent.com/2832627/108603003-9e71fa80-73a5-11eb-90ce-dfe4384e4de3.png)