### PR TITLE
⚡️ (viewer) Improve performance for recent actions

### DIFF
--- a/viewer/src/components/BoardAction.spec.ts
+++ b/viewer/src/components/BoardAction.spec.ts
@@ -9,6 +9,8 @@ function makeTestStore() {
   (store as any).getters = {
     "gaiaViewer/recentCommands": () => [],
     "gaiaViewer/currentRoundCommands": () => [],
+    "gaiaViewer/recentHexes": () => new Set(),
+    "gaiaViewer/currentRoundHexes": () => new Set(),
   };
   return store;
 }

--- a/viewer/src/components/PlayerBoard/BuildingGroup.vue
+++ b/viewer/src/components/PlayerBoard/BuildingGroup.vue
@@ -184,14 +184,14 @@ export default class BuildingGroup extends Vue {
 
   recentlyBuilt(i: number): boolean {
     return this.shouldMarkBuilding(
-      this.$store.getters["gaiaViewer/currentRoundCommands"],
-      this.$store.getters["gaiaViewer/recentCommands"],
+      this.$store.getters["gaiaViewer/currentRoundBuildingCommands"].get(this.faction) ?? [],
+      this.$store.getters["gaiaViewer/recentBuildingCommands"].get(this.faction) ?? [],
       i
     );
   }
 
   currentRoundBuilt(i: number): boolean {
-    const commands = this.$store.getters["gaiaViewer/currentRoundCommands"];
+    const commands = this.$store.getters["gaiaViewer/currentRoundBuildingCommands"].get(this.faction) ?? [];
     return this.shouldMarkBuilding(commands, commands, i);
   }
 
@@ -204,9 +204,8 @@ export default class BuildingGroup extends Vue {
       b = BuildingEnum.Academy2;
       i--;
     }
-    const f = this.faction;
     function countMoves(commands: CommandObject[]) {
-      return commands.filter((c) => c.faction == f && c.command == Command.Build && c.args[0] as BuildingEnum === b).length;
+      return commands.filter((c) => (c.args[0] as BuildingEnum) === b).length;
     }
 
     return markBuilding(i, countMoves(roundMoves), this.placed, countMoves(moves), this.nBuildings);

--- a/viewer/src/components/PlayerBoard/Info.vue
+++ b/viewer/src/components/PlayerBoard/Info.vue
@@ -103,7 +103,6 @@ import { uniq } from "lodash";
 import Resource from "../Resource.vue";
 import { Faction, factions, Player, PlayerData, ResearchField, Resource as ResourceEnum } from "@gaia-project/engine";
 import VictoryPoint from "../Resources/VictoryPoint.vue";
-import { researchClass } from "../../logic/recent";
 
 @Component({
   components: {
@@ -140,14 +139,8 @@ export default class BuildingGroup extends Vue {
   }
 
   researchClass(index: number): string {
-    const field = this.researchType(index);
     return (
-      researchClass(
-        this.$store.getters["gaiaViewer/recentCommands"],
-        this.$store.getters["gaiaViewer/currentRoundCommands"],
-        field,
-        this.faction
-      ) ?? ""
+      this.$store.getters["gaiaViewer/researchClasses"].get(this.player.faction)?.get(this.researchType(index)) ?? ""
     );
   }
 

--- a/viewer/src/components/ResearchTile.vue
+++ b/viewer/src/components/ResearchTile.vue
@@ -73,7 +73,6 @@ import Token from "./Token.vue";
 import FederationTile from "./FederationTile.vue";
 import Planet from "./Planet.vue";
 import Resource from "./Resource.vue";
-import { researchClass } from "../logic/recent";
 
 @Component<ResearchTile>({
   components: {
@@ -183,11 +182,14 @@ export default class ResearchTile extends Vue {
 
     if (this.level >= 4) {
       const tilePos = ("adv-" + this.field) as AdvTechTilePos;
-      if (canTakeAdvancedTechTile(this.gameData, player.data, tilePos) || canResearchField(this.gameData, player, this.field)) {
+      if (
+        canTakeAdvancedTechTile(this.gameData, player.data, tilePos) ||
+        canResearchField(this.gameData, player, this.field)
+      ) {
         classes.push("warn");
       }
     }
-    const c = researchClass(this.$store.getters["gaiaViewer/recentCommands"], this.$store.getters["gaiaViewer/currentRoundCommands"], this.field, player.faction);
+    const c = this.$store.getters["gaiaViewer/researchClasses"].get(player.faction)?.get(this.field);
     if (c) {
       classes.push(c);
     }

--- a/viewer/src/components/SpaceHex.vue
+++ b/viewer/src/components/SpaceHex.vue
@@ -67,7 +67,6 @@ import Planet from "./Planet.vue";
 import Building from "./Building.vue";
 import { buildingName } from "../data/building";
 import { planetNames } from "../data/planets";
-import { movesToHexes } from "../logic/recent";
 
 @Component<SpaceHex>({
   components: {
@@ -130,11 +129,11 @@ export default class SpaceHex extends Vue {
   }
 
   recent(hex: GaiaHex): boolean {
-    return movesToHexes(this.gameData, this.$store.getters["gaiaViewer/recentCommands"]).includes(hex);
+    return this.$store.getters["gaiaViewer/recentHexes"].has(hex);
   }
 
   currentRound(hex: GaiaHex): boolean {
-    return movesToHexes(this.gameData, this.$store.getters["gaiaViewer/currentRoundCommands"]).includes(hex);
+    return this.$store.getters["gaiaViewer/currentRoundHexes"].has(hex);
   }
 
   get gameData(): Engine {

--- a/viewer/src/logic/recent.ts
+++ b/viewer/src/logic/recent.ts
@@ -81,18 +81,26 @@ function containsCommand(recentMoves: CommandObject[], field: ResearchField, fac
   return recentMoves.some((c) => c.faction == faction && c.command == Command.UpgradeResearch && c.args[0] == field);
 }
 
-export function researchClass(
+export function researchClasses(
   recent: CommandObject[],
-  round: CommandObject[],
-  field: ResearchField,
-  faction: Faction
-): string | null {
-  if (containsCommand(recent, field, faction)) {
-    return "recent";
+  round: CommandObject[]
+): Map<Faction, Map<ResearchField, "recent" | "currentRound">> {
+  const classes = new Map<Faction, Map<ResearchField, "recent" | "currentRound">>();
+  for (const move of round) {
+    if (move.command === Command.UpgradeResearch) {
+      if (!classes.has(move.faction)) {
+        classes.set(move.faction, new Map());
+      }
+      classes.get(move.faction).set(move.args[0] as ResearchField, "currentRound");
+    }
   }
-  if (containsCommand(round, field, faction)) {
-    return "current-round";
+  for (const move of recent) {
+    if (move.command === Command.UpgradeResearch) {
+      if (!classes.has(move.faction)) {
+        classes.set(move.faction, new Map());
+      }
+      classes.get(move.faction).set(move.args[0] as ResearchField, "recent");
+    }
   }
-
-  return null;
+  return classes;
 }

--- a/viewer/src/store.ts
+++ b/viewer/src/store.ts
@@ -11,7 +11,7 @@ import { CubeCoordinates } from "hexagrid";
 import Vue from "vue";
 import Vuex, { Store } from "vuex";
 import { ButtonData, GameContext } from "./data";
-import { CommandObject, parseCommands, recentMoves, roundMoves } from "./logic/recent";
+import { CommandObject, movesToHexes, parseCommands, recentMoves, roundMoves } from "./logic/recent";
 
 Vue.use(Vuex);
 
@@ -153,6 +153,12 @@ const gaiaViewer = {
         return recentMoves(player, data.advancedLog, data.moveHistory).flatMap((m) => parseCommands(m));
       }
       return [];
+    },
+    recentHexes: (state: State, getters): Set<GaiaHex> => {
+      return new Set(movesToHexes(state.data, getters.recentCommands));
+    },
+    currentRoundHexes: (state: State, getters): Set<GaiaHex> => {
+      return new Set(movesToHexes(state.data, getters.currentRoundCommands));
     },
   },
 };

--- a/viewer/src/store.ts
+++ b/viewer/src/store.ts
@@ -1,6 +1,7 @@
 import Engine, {
   AdvTechTilePos,
   Booster,
+  Faction,
   Federation,
   GaiaHex,
   Player,
@@ -11,7 +12,7 @@ import { CubeCoordinates } from "hexagrid";
 import Vue from "vue";
 import Vuex, { Store } from "vuex";
 import { ButtonData, GameContext } from "./data";
-import { CommandObject, movesToHexes, parseCommands, recentMoves, roundMoves } from "./logic/recent";
+import { CommandObject, movesToHexes, parseCommands, recentMoves, researchClasses, roundMoves } from "./logic/recent";
 
 Vue.use(Vuex);
 
@@ -159,6 +160,9 @@ const gaiaViewer = {
     },
     currentRoundHexes: (state: State, getters): Set<GaiaHex> => {
       return new Set(movesToHexes(state.data, getters.currentRoundCommands));
+    },
+    researchClasses: (state: State, getters): Map<Faction, Map<ResearchField, "recent" | "currentRound">> => {
+      return researchClasses(getters.recentCommands, getters.currentRoundCommands);
     },
   },
 };

--- a/viewer/src/store.ts
+++ b/viewer/src/store.ts
@@ -1,6 +1,7 @@
 import Engine, {
   AdvTechTilePos,
   Booster,
+  Command,
   Faction,
   Federation,
   GaiaHex,
@@ -163,6 +164,34 @@ const gaiaViewer = {
     },
     researchClasses: (state: State, getters): Map<Faction, Map<ResearchField, "recent" | "currentRound">> => {
       return researchClasses(getters.recentCommands, getters.currentRoundCommands);
+    },
+    recentBuildingCommands: (state: State, getters): Map<Faction, CommandObject[]> => {
+      const map = new Map<Faction, CommandObject[]>();
+
+      for (const command of getters.recentCommands as CommandObject[]) {
+        if (command.command === Command.Build) {
+          if (!map.has(command.faction)) {
+            map.set(command.faction, []);
+          }
+          map.get(command.faction).push(command);
+        }
+      }
+
+      return map;
+    },
+    currentRoundBuildingCommands: (state: State, getters): Map<Faction, CommandObject[]> => {
+      const map = new Map<Faction, CommandObject[]>();
+
+      for (const command of getters.currentRoundCommands as CommandObject[]) {
+        if (command.command === Command.Build) {
+          if (!map.has(command.faction)) {
+            map.set(command.faction, []);
+          }
+          map.get(command.faction).push(command);
+        }
+      }
+
+      return map;
     },
   },
 };


### PR DESCRIPTION
Currently only the hexes, but should consider others. Eg not reparse every current round commands for every building on every faction board.