### PR TITLE
💫 (viewer) Show all chart controls at once

### DIFF
--- a/viewer/src/assets/resources/bar-chart.svg
+++ b/viewer/src/assets/resources/bar-chart.svg
@@ -1,15 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" viewBox="0 -256 512 512" id="svg3001" version="1.1" inkscape:version="0.48.4 r9939" width="512" height="512" sodipodi:docname="Bar_chart_font_awesome.svg">
-  <metadata id="metadata3011">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <defs />
   <sodipodi:namedview inkscape:zoom="1" inkscape:cx="118.9414" inkscape:cy="228.84004" inkscape:window-width="1871" inkscape:window-height="1176" inkscape:window-x="49" inkscape:window-y="24" inkscape:window-maximized="1" inkscape:current-layer="svg3001" />
-  <path id="rect5686" style="fill:#000000" d="m 271.1864,490.54239 254.90105,0 0,1024.00001 -254.90105,0 z m -382.35154,-1365.33332 254.90105,0 0,2389.33333 -254.90105,0 z m -382.35157,682.66667 254.90105,0 0,1706.66666 -254.90105,0 z m -382.35156,-1024.00004 254.90105,0 0,2730.6667 -254.90105,0 z m -95.5868,-683.0297 c -88.25943,0 -159.31313,190.2933 -159.31313,426.6667 l 0,3242.9166 c 0,236.3734 71.0537,426.6667 159.31313,426.6667 l 1593.13154,0 c 88.25948,0 159.31315,-190.2933 159.31315,-426.6667 l 0,-3242.9166 c 0,-236.3734 -71.05367,-426.6667 -159.31315,-426.6667 l -1593.13154,0 z m 0.49786,341.6667 1592.13582,0 c 17.92771,0 32.36049,38.6533 32.36049,86.6666 l 0,3240.0834 c 0,48.0133 -14.43278,86.6666 -32.36049,86.6666 l -1592.13582,0 c -17.92771,0 -32.36049,-38.6533 -32.36049,-86.6666 l 0,-3240.0834 c 0,-48.0133 14.43278,-86.6666 32.36049,-86.6666 z" inkscape:connector-curvature="0" transform="matrix(0.26257899,0,0,0.09804443,303.1035,-5.7125656)" />
+  <path id="rect5686" fill="black" d="m 271.1864,490.54239 254.90105,0 0,1024.00001 -254.90105,0 z m -382.35154,-1365.33332 254.90105,0 0,2389.33333 -254.90105,0 z m -382.35157,682.66667 254.90105,0 0,1706.66666 -254.90105,0 z m -382.35156,-1024.00004 254.90105,0 0,2730.6667 -254.90105,0 z m -95.5868,-683.0297 c -88.25943,0 -159.31313,190.2933 -159.31313,426.6667 l 0,3242.9166 c 0,236.3734 71.0537,426.6667 159.31313,426.6667 l 1593.13154,0 c 88.25948,0 159.31315,-190.2933 159.31315,-426.6667 l 0,-3242.9166 c 0,-236.3734 -71.05367,-426.6667 -159.31315,-426.6667 l -1593.13154,0 z m 0.49786,341.6667 1592.13582,0 c 17.92771,0 32.36049,38.6533 32.36049,86.6666 l 0,3240.0834 c 0,48.0133 -14.43278,86.6666 -32.36049,86.6666 l -1592.13582,0 c -17.92771,0 -32.36049,-38.6533 -32.36049,-86.6666 l 0,-3240.0834 c 0,-48.0133 14.43278,-86.6666 32.36049,-86.6666 z" inkscape:connector-curvature="0" transform="matrix(0.26257899,0,0,0.09804443,303.1035,-5.7125656)" />
 </svg>

--- a/viewer/src/assets/resources/line-chart.svg
+++ b/viewer/src/assets/resources/line-chart.svg
@@ -1,6 +1,3 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="512px" height="512px" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
 <g>
@@ -14,35 +11,5 @@
 		s-7.156-16-16-16S448,103.156,448,112z M352,304c0,8.844,7.156,16,16,16s16-7.156,16-16s-7.156-16-16-16S352,295.156,352,304z
 		 M224,208c0,8.844,7.156,16,16,16s16-7.156,16-16s-7.156-16-16-16S224,199.156,224,208z M128,336c0,8.844,7.156,16,16,16
 		s16-7.156,16-16s-7.156-16-16-16S128,327.156,128,336z"/>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
 </g>
 </svg>

--- a/viewer/src/components/PlayerCircle.vue
+++ b/viewer/src/components/PlayerCircle.vue
@@ -20,7 +20,7 @@ export default class PlayerCircle extends Vue {
   @Prop()
   player: Player;
 
-  @Prop()
+  @Prop({ type: Boolean, default: false })
   chart: boolean;
 
   get gameData(): Engine {


### PR DESCRIPTION
Also center them and apply selected colors to lineChart / barChart svgs

![image](https://user-images.githubusercontent.com/342922/110258006-c2862c00-7fa0-11eb-91d6-35fbd23db08e.png)

The issue is that on the default screen, the user might not realize that the top left icon is clickable, and miss out on the various kind of charts