### PR TITLE
✨ (viewer) Hide logs until end of turn.

### DIFF
--- a/viewer/src/components/AdvancedLog.vue
+++ b/viewer/src/components/AdvancedLog.vue
@@ -5,6 +5,7 @@
         <b-form-radio value="recent">Recent</b-form-radio>
         <b-form-radio value="all">Everything</b-form-radio>
       </b-form-radio-group>
+      <b-checkbox :checked="hideLog" @change="toggleLog">Hide log until next turn</b-checkbox>
     </div>
     <table class="table table-hover table-striped table-sm">
       <tbody>
@@ -64,6 +65,13 @@ export default class AdvancedLog extends Vue {
   @Prop()
   currentMove?: string;
 
+  @Prop()
+  hideLog?: boolean;
+
+  toggleLog() {
+    this.$emit("update:hideLog", !this.hideLog);
+  }
+
   setScope(scope: LogScope) {
     this.scope = scope;
   }
@@ -73,7 +81,14 @@ export default class AdvancedLog extends Vue {
   }
 
   get history(): HistoryEntry[] {
-    return makeHistory(this.gameData, this.$store.getters["gaiaViewer/recentMoves"], this.scope == "recent", this.currentMove);
+    if (this.hideLog) return [];
+
+    return makeHistory(
+      this.gameData,
+      this.$store.getters["gaiaViewer/recentMoves"],
+      this.scope == "recent",
+      this.currentMove
+    );
   }
 
   rowSpan(entry: HistoryEntry): number {

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -52,7 +52,12 @@
         />
       </div>
     </div>
-    <AdvancedLog class="col-12 order-last mt-4" :currentMove="currentMove" v-if="logPlacement === 'top'" />
+    <AdvancedLog
+      class="col-12 order-last mt-4"
+      :currentMove="currentMove"
+      :hideLog.sync="hideLog"
+      v-if="logPlacement === 'top'"
+    />
     <div class="row mt-2">
       <template v-if="sessionPlayer === undefined">
         <PlayerInfo v-for="player in orderedPlayers" :player="player" :key="player.player" class="col-md-6 order-6" />
@@ -67,7 +72,12 @@
         />
       </template>
       <Pool class="col-12 order-10 mt-4" />
-      <AdvancedLog class="col-12 order-last mt-4" :currentMove="currentMove" v-if="logPlacement === 'bottom'" />
+      <AdvancedLog
+        class="col-12 order-last mt-4"
+        :currentMove="currentMove"
+        :hideLog.sync="hideLog"
+        v-if="logPlacement === 'bottom'"
+      />
     </div>
   </div>
 </template>
@@ -174,6 +184,7 @@ export default class Game extends Vue {
   private finalScoringFields: any[] = null
   private finalScoringItems: any[] = null
   public currentMove = "";
+  public hideLog = false;
   public currentMoveWarnings: Map<string, BuildWarning[]> = new Map<string, BuildWarning[]>();
   clearCurrentMove = false;
   // When joining a game
@@ -276,6 +287,7 @@ export default class Game extends Vue {
 
     if (data.newTurn) {
       this.currentMove = "";
+      this.hideLog = false;
       this.currentMoveWarnings.clear();
     } else {
       this.currentMove = data.moveHistory.pop() ?? "";


### PR DESCRIPTION
Hello! I have recently started playing this game *seriously* thanks to this project, and I am extremely thankful 🙇 

My personal favorite workflow is to keep the log placement on "top" with the log set to "recent", so that I can review what has changed since I made my last move. Then I prefer to hide the log while I scroll back and forth from the game board and my player board, which I frequently do on mobile. Adding an explicit option to hide the logs *for now* without having to open the preferences sidebar will make this workflow much easier.

I work professionally with React and haven't touched Vue in a while, please let me know if I can make this any more idiomatic or better fit in with the existing code style. Or if you have no interest in supporting this feature, I also would totally understand 😃 