### PR TITLE
🐛 (engine) Load factions only after bidding

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -382,7 +382,11 @@ describe("Engine", () => {
         p3 bid gleens 1
         p2 bid bescods 0
       `);
-      const engine = Engine.slowMotion(moves, { auction: AuctionVariant.ChooseBid, factionVariant: "more-balanced" });
+      const engine = Engine.slowMotion(
+        moves,
+        { auction: AuctionVariant.ChooseBid, factionVariant: "more-balanced" },
+        "4.8.4"
+      );
       expect(engine.player(PlayerEnum.Player2).faction).to.equal(Faction.Bescods);
       expect(engine.player(PlayerEnum.Player2).data.research.nav).to.equal(0);
     });

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { BoardAction, Booster, Building, PlayerEnum } from "..";
 import { version } from "../package.json";
 import Engine, { AuctionVariant, createMoveToShow } from "./engine";
-import { Command, Condition, Operator, Phase, Planet, Player } from "./enums";
+import { Command, Condition, Faction, Operator, Phase, Planet, Player } from "./enums";
 import PlayerData, { MoveTokens } from "./player-data";
 
 describe("Engine", () => {
@@ -369,6 +369,22 @@ describe("Engine", () => {
           expect(Engine.fromData(data).boardActions[BoardAction.Power1]).to.equal(test.want);
         });
       }
+    });
+
+    it("should not cause factions to get messed up", () => {
+      const moves = parseMoves(`
+        init 3 Swift-farm-7018
+        p1 faction lantids
+        p2 faction gleens
+        p3 faction bescods
+        p1 bid lantids 0
+        p2 bid gleens 0
+        p3 bid gleens 1
+        p2 bid bescods 0
+      `);
+      const engine = Engine.slowMotion(moves, { auction: AuctionVariant.ChooseBid, factionVariant: "more-balanced" });
+      expect(engine.player(PlayerEnum.Player2).faction).to.equal(Faction.Bescods);
+      expect(engine.player(PlayerEnum.Player2).data.research.nav).to.equal(0);
     });
   });
 

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -990,11 +990,10 @@ export default class Engine {
 
   endSetupFactionPhase() {
     for (const pl of this.players) {
-      if (pl.faction) {
-        pl.loadFaction(pl.faction, this.factionCustomization, this.expansions);
-      } else {
-        pl.loadFaction(this.setup[pl.player as PlayerEnum], this.factionCustomization, this.expansions);
+      if (!pl.faction) {
+        pl.faction = this.setup[pl.player as PlayerEnum];
       }
+      pl.loadFaction(this.factionCustomization, this.expansions);
     }
 
     this.beginSetupBuildingPhase();

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
 import { isEqual, range, set, uniq } from "lodash";
-import semVerCompare from "semver-compare";
 import shuffleSeed from "shuffle-seed";
 import { version } from "../package.json";
 import { boardActions } from "./actions";
@@ -42,6 +41,7 @@ import Reward from "./reward";
 import federations from "./tiles/federations";
 import { roundScorings } from "./tiles/scoring";
 import { isAdvanced } from "./tiles/techs";
+import { isVersionOrLater } from "./utils";
 
 // const ISOLATED_DISTANCE = 3;
 const LEECHING_DISTANCE = 2;
@@ -264,8 +264,7 @@ export default class Engine {
   }
 
   isVersionOrLater(version: string) {
-    if (!this.version) return false;
-    return semVerCompare(this.version, version) !== -1;
+    return isVersionOrLater(this.version, version);
   }
 
   loadMoves(_moves: string[]) {
@@ -696,7 +695,7 @@ export default class Engine {
       players: data.players.length,
     };
     for (const player of data.players) {
-      engine.addPlayer(Player.fromData(player, engine.map, customization, engine.expansions));
+      engine.addPlayer(Player.fromData(player, engine.map, customization, engine.expansions, engine.version));
     }
 
     if (data.map) {
@@ -740,11 +739,11 @@ export default class Engine {
     return jsonObj;
   }
 
-  static slowMotion([first, ...moves]: string[], options: EngineOptions = {}): Engine {
+  static slowMotion([first, ...moves]: string[], options: EngineOptions = {}, version: string = null): Engine {
     if (!first) {
-      return new Engine([], options);
+      return new Engine([], options, version);
     }
-    let state = JSON.parse(JSON.stringify(new Engine([first], options)));
+    let state = JSON.parse(JSON.stringify(new Engine([first], options, version)));
 
     for (const move of moves) {
       const tempEngine = Engine.fromData(state);

--- a/engine/src/player.spec.ts
+++ b/engine/src/player.spec.ts
@@ -1,17 +1,21 @@
 import { expect } from "chai";
 import "mocha";
+import { FactionCustomization } from "./engine";
 import { Building, Faction, Operator, Planet, Player as PlayerEnum, Resource } from "./enums";
 import Event from "./events";
 import { GaiaHex } from "./gaia-hex";
 import Player from "./player";
 import Reward from "./reward";
 
+const standard: FactionCustomization = { players: 2, variant: "standard" };
+
 describe("Player", () => {
   describe("canBuild", () => {
     it("should take addedCost into account", () => {
       const player = new Player(PlayerEnum.Player1);
 
-      player.loadFaction(Faction.Terrans);
+      player.faction = Faction.Terrans;
+      player.loadFaction(standard);
 
       const { cost } = player.canBuild(Planet.Terra, Building.Mine, { addedCost: [new Reward(1, Resource.Qic)] });
 
@@ -49,7 +53,8 @@ describe("Player", () => {
     it("should allow lantids to occupy an hex used by another faction", () => {
       const player = new Player();
 
-      player.loadFaction(Faction.Lantids);
+      player.faction = Faction.Lantids;
+      player.loadFaction(standard);
       const hex = new GaiaHex(0, 0, {
         sector: "s1",
         planet: Planet.Lost,

--- a/engine/src/player.ts
+++ b/engine/src/player.ts
@@ -42,6 +42,7 @@ import boosts from "./tiles/boosters";
 import federationTiles, { isGreen } from "./tiles/federations";
 import { finalScorings } from "./tiles/scoring";
 import techs, { isAdvanced } from "./tiles/techs";
+import { isVersionOrLater } from "./utils";
 
 // 25 satellites total
 // The 2 used on the final scoring board and 1 used in the player order can be replaced by other markers
@@ -146,6 +147,7 @@ export default class Player extends EventEmitter {
       name: this.name,
       dropped: this.dropped,
       factionVariant: this.factionVariant,
+      factionLoaded: !!this.board,
     } as any;
 
     if (this.federationCache) {
@@ -161,11 +163,11 @@ export default class Player extends EventEmitter {
     return json;
   }
 
-  static fromData(data: any, map: SpaceMap, customization: FactionCustomization, expansions: number) {
+  static fromData(data: any, map: SpaceMap, customization: FactionCustomization, expansions: number, version: string) {
     const player = new Player(data.player);
 
     player.faction = data.faction;
-    if (data.faction) {
+    if (data.faction && (data.factionLoaded || !isVersionOrLater(version, "4.8.4"))) {
       player.factionVariant = data.factionVariant;
       player.loadFaction(customization, expansions, true);
     }

--- a/engine/src/player.ts
+++ b/engine/src/player.ts
@@ -163,10 +163,11 @@ export default class Player extends EventEmitter {
 
   static fromData(data: any, map: SpaceMap, customization: FactionCustomization, expansions: number) {
     const player = new Player(data.player);
-    player.factionVariant = data.factionVariant;
 
+    player.faction = data.faction;
     if (data.faction) {
-      player.loadFaction(data.faction, customization, expansions, true);
+      player.factionVariant = data.factionVariant;
+      player.loadFaction(customization, expansions, true);
     }
 
     for (const kind of Object.keys(data.events)) {
@@ -339,10 +340,9 @@ export default class Player extends EventEmitter {
     return this.data.occupied.filter((hex) => hex.data.planet !== Planet.Empty && hex.isMainOccupier(this.player));
   }
 
-  loadFaction(faction: Faction, customization: FactionCustomization, expansions = 0, skipIncome = false) {
-    this.faction = faction;
-    this.factionVariant = this.factionVariant ?? factionVariantBoard(customization, faction);
-    this.board = factionBoard(faction, this.factionVariant);
+  loadFaction(customization: FactionCustomization, expansions = 0, skipIncome = false) {
+    this.factionVariant = this.factionVariant ?? factionVariantBoard(customization, this.faction);
+    this.board = factionBoard(this.faction, this.factionVariant);
 
     if (!skipIncome) {
       this.loadTechs(expansions);

--- a/engine/src/utils.ts
+++ b/engine/src/utils.ts
@@ -1,4 +1,5 @@
 import { mergeWith } from "lodash";
+import semVerCompare from "semver-compare";
 
 function customizer(objValue, srcValue) {
   if (Array.isArray(objValue)) {
@@ -24,4 +25,9 @@ export function combinations<T>(t: T[]): T[][] {
     return [[]];
   }
   return combinations(t.slice(1)).flatMap((value) => [value, value.concat(t[0])]);
+}
+
+export function isVersionOrLater(actualVersion: string, requiredVersion: string) {
+  if (!actualVersion) return false;
+  return semVerCompare(actualVersion, requiredVersion) !== -1;
 }


### PR DESCRIPTION
Fixes #97 

The faction variant is stored and loaded from the json. This will cause changes in the balanced set to be pinned for the whole game. However, when bidding, the faction can change owner. This caused the wrong variant to load.