### PR TITLE
Minor cleanup

### DIFF
--- a/engine/index.ts
+++ b/engine/index.ts
@@ -14,7 +14,14 @@ import federations from "./src/tiles/federations";
 
 export { boardActions } from "./src/actions";
 export { AvailableHex, canResearchField, canTakeAdvancedTechTile, HighlightHex } from "./src/available-command";
-export { AuctionVariant, EngineOptions, FactionVariant, LogEntry, LogEntryChanges } from "./src/engine";
+export {
+  AuctionVariant,
+  EngineOptions,
+  FactionCustomization,
+  FactionVariant,
+  LogEntry,
+  LogEntryChanges,
+} from "./src/engine";
 export {
   AdvTechTile,
   AdvTechTilePos,
@@ -42,7 +49,7 @@ export {
   TechTile,
   TechTilePos,
 } from "./src/enums";
-export { FactionBoard, factionBoard } from "./src/faction-boards";
+export { FactionBoard, factionBoard, factionVariantBoard } from "./src/faction-boards";
 export { factionPlanet } from "./src/factions";
 export { GaiaHex, GaiaHexData } from "./src/gaia-hex";
 export { applyChargePowers } from "./src/income";

--- a/viewer/src/components/PlayerBoard/BuildingGroup.vue
+++ b/viewer/src/components/PlayerBoard/BuildingGroup.vue
@@ -72,9 +72,11 @@ import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import Building from "../Building.vue";
 import Resource from "../Resource.vue";
-import {
+import Engine, {
   Building as BuildingEnum,
   factionBoard,
+  FactionCustomization,
+  factionVariantBoard,
   Operator,
   Player,
   Resource as ResourceEnum,
@@ -117,7 +119,12 @@ export default class BuildingGroup extends Vue {
   ac2: boolean;
 
   get board() {
-    return this.player.board ?? factionBoard(this.faction, this.player.factionVariant);
+    if (this.player.board) {
+      return this.player.board;
+    }
+    const engine = this.$store.state.gaiaViewer.data as Engine;
+    const factionVariant = factionVariantBoard(engine.factionCustomization, this.faction);
+    return factionBoard(this.faction, factionVariant);
   }
 
   get faction() {

--- a/viewer/src/logic/victory-point-charts.ts
+++ b/viewer/src/logic/victory-point-charts.ts
@@ -25,10 +25,10 @@ import {
   logEntryProcessor,
 } from "./charts";
 
-function simulateIncome(pl: Player, consume: (p: Player) => void): number {
+function simulateIncome(pl: Player, consume: (p: Player) => void, engineVersion: string): number {
   const json = JSON.parse(JSON.stringify(pl));
   delete json.federationCache; // otherwise we need to pass the map when loading
-  const clone = Player.fromData(json, null, null, 0, null);
+  const clone = Player.fromData(json, null, null, 0, engineVersion);
   consume(clone);
   return clone.data.victoryPoints - pl.data.victoryPoints;
 }
@@ -177,8 +177,11 @@ export const victoryPointSources: VictoryPointSource[] = [
     color: "--rt-sci",
     aggregate: finalScoring,
     projectedEndValue: (engine: Engine, pl: Player) =>
-      simulateIncome(pl, (clone) =>
-        gainFinalScoringVictoryPoints(finalRankings([engine.tiles.scorings.final[0]], engine.players), clone)
+      simulateIncome(
+        pl,
+        (clone) =>
+          gainFinalScoringVictoryPoints(finalRankings([engine.tiles.scorings.final[0]], engine.players), clone),
+        engine.version
       ),
   },
   {
@@ -188,8 +191,11 @@ export const victoryPointSources: VictoryPointSource[] = [
     color: "--dig",
     aggregate: finalScoring,
     projectedEndValue: (engine: Engine, pl: Player) =>
-      simulateIncome(pl, (clone) =>
-        gainFinalScoringVictoryPoints(finalRankings([engine.tiles.scorings.final[1]], engine.players), clone)
+      simulateIncome(
+        pl,
+        (clone) =>
+          gainFinalScoringVictoryPoints(finalRankings([engine.tiles.scorings.final[1]], engine.players), clone),
+        engine.version
       ),
   },
   {
@@ -197,7 +203,8 @@ export const victoryPointSources: VictoryPointSource[] = [
     label: "Resources",
     description: "Points for the remaining resources converted to credits",
     color: "--res-credit",
-    projectedEndValue: (_: Engine, pl: Player) => simulateIncome(pl, (clone) => clone.data.finalResourceHandling()),
+    projectedEndValue: (e: Engine, pl: Player) =>
+      simulateIncome(pl, (clone) => clone.data.finalResourceHandling(), e.version),
   },
 ];
 
@@ -282,7 +289,7 @@ export function victoryPointDetails(
     const deltaForEnded = () => {
       if (s.types.includes(Command.UpgradeResearch)) {
         // research was already counted in chart separately
-        return -simulateIncome(pl, (clone) => clone.data.gainResearchVictoryPoints());
+        return -simulateIncome(pl, (clone) => clone.data.gainResearchVictoryPoints(), data.version);
       }
       return 0;
     };


### PR DESCRIPTION
- As `Player.fromData` now requires the version of the engine, pass it along. The engine happened to be available at all call sites.
- Load the proper board when the `Player` has not loaded its faction yet.