### PR TITLE
♻️ (all) Encapsulate faction list, move name to UI

### DIFF
--- a/engine/index.ts
+++ b/engine/index.ts
@@ -3,7 +3,6 @@ import AvailableCommand from "./src/available-command";
 import { stdBuildingValue } from "./src/buildings";
 import Engine from "./src/engine";
 import Event, { EventSource } from "./src/events";
-import factions from "./src/factions";
 import SpaceMap, { parseLocation } from "./src/map";
 import Player, { BuildWarning } from "./src/player";
 import PlayerData from "./src/player-data";
@@ -74,7 +73,6 @@ export {
   Player,
   PlayerData,
   Event,
-  factions,
   AvailableCommand,
   tiles,
   Reward,

--- a/engine/src/available-command.spec.ts
+++ b/engine/src/available-command.spec.ts
@@ -1,27 +1,27 @@
 import { expect } from "chai";
 import { PlayerEnum } from "../index";
-import { possibleBoardActions, possibleFreeActions, remainingFactions } from "./available-command";
+import { choosableFactions, possibleBoardActions, possibleFreeActions } from "./available-command";
 import Engine, { AuctionVariant } from "./engine";
 import { BoardAction, Faction } from "./enums";
 import Player from "./player";
 import PlayerData from "./player-data";
 
 describe("Available commands", () => {
-  describe("remainingFactions", () => {
+  describe("choosableFactions", () => {
     it("should show all factions at the beginning", () => {
       const engine = new Engine();
 
-      expect(remainingFactions(engine)).to.have.members(Object.values(Faction));
+      expect(choosableFactions(engine)).to.have.members(Object.values(Faction));
     });
 
     it("should show 2 less factions after one is selected", () => {
       const engine = new Engine();
 
-      expect(remainingFactions(engine)).to.include.members([Faction.Gleens, Faction.Xenos]);
+      expect(choosableFactions(engine)).to.include.members([Faction.Gleens, Faction.Xenos]);
 
       engine.setup.push(Faction.Gleens);
 
-      const factions = remainingFactions(engine);
+      const factions = choosableFactions(engine);
 
       expect(factions).to.not.include(Faction.Gleens);
       expect(factions).to.not.include(Faction.Xenos);
@@ -32,44 +32,44 @@ describe("Available commands", () => {
       it("should give only one faction at a time", () => {
         const engine = new Engine([`init 3 12`], { randomFactions: true });
 
-        expect(remainingFactions(engine)).to.eql([Faction.Bescods]);
+        expect(choosableFactions(engine)).to.eql([Faction.Bescods]);
 
         engine.setup.push(Faction.Bescods);
 
-        expect(remainingFactions(engine)).to.eql([Faction.Gleens]);
+        expect(choosableFactions(engine)).to.eql([Faction.Gleens]);
 
         engine.setup.push(Faction.Gleens);
 
-        expect(remainingFactions(engine)).to.eql([Faction.BalTaks]);
+        expect(choosableFactions(engine)).to.eql([Faction.BalTaks]);
       });
 
       describe("when auction is enabled", () => {
         it("should offer factions from a randomly selected pool (bid-while-choosing)", () => {
           const engine = new Engine([`init 3 12`], { randomFactions: true, auction: AuctionVariant.BidWhileChoosing });
-          expect(remainingFactions(engine)).to.have.members([Faction.Bescods, Faction.Gleens, Faction.BalTaks]);
+          expect(choosableFactions(engine)).to.have.members([Faction.Bescods, Faction.Gleens, Faction.BalTaks]);
 
           engine.setup.push(Faction.Gleens);
-          expect(remainingFactions(engine)).to.have.members([Faction.Bescods, Faction.BalTaks]);
+          expect(choosableFactions(engine)).to.have.members([Faction.Bescods, Faction.BalTaks]);
 
           engine.setup.push(Faction.BalTaks);
-          expect(remainingFactions(engine)).to.eql([Faction.Bescods]);
+          expect(choosableFactions(engine)).to.eql([Faction.Bescods]);
 
           engine.setup.push(Faction.Bescods);
-          expect(remainingFactions(engine)).to.eql([]);
+          expect(choosableFactions(engine)).to.eql([]);
         });
 
         it("should give one faction at a time (choose-bid)", () => {
           const engine = new Engine([`init 3 12`], { randomFactions: true, auction: AuctionVariant.ChooseBid });
-          expect(remainingFactions(engine)).to.eql([Faction.Bescods]);
+          expect(choosableFactions(engine)).to.eql([Faction.Bescods]);
 
           engine.setup.push(Faction.Bescods);
-          expect(remainingFactions(engine)).to.eql([Faction.Gleens]);
+          expect(choosableFactions(engine)).to.eql([Faction.Gleens]);
 
           engine.setup.push(Faction.Gleens);
-          expect(remainingFactions(engine)).to.eql([Faction.BalTaks]);
+          expect(choosableFactions(engine)).to.eql([Faction.BalTaks]);
 
           engine.setup.push(Faction.BalTaks);
-          expect(remainingFactions(engine)).to.eql([]);
+          expect(choosableFactions(engine)).to.eql([]);
         });
       });
     });

--- a/engine/src/available-command.ts
+++ b/engine/src/available-command.ts
@@ -31,7 +31,7 @@ import {
   TechTile,
   TechTilePos,
 } from "./enums";
-import { oppositeFaction } from "./factions";
+import { remainingFactions } from "./factions";
 import { GaiaHex } from "./gaia-hex";
 import SpaceMap from "./map";
 import PlayerObject, { BuildCheck, BuildWarning } from "./player";
@@ -969,7 +969,19 @@ export function possiblePISwaps(engine: Engine, player: Player) {
   return commands;
 }
 
-export function remainingFactions(engine: Engine) {
+function chooseFactionOrBid(engine: Engine, player: Player): AvailableCommand<Command.Bid | Command.ChooseFaction>[] {
+  const chooseFaction: AvailableCommand<Command.Bid | Command.ChooseFaction> = {
+    name: Command.ChooseFaction,
+    player,
+    data: choosableFactions(engine),
+  };
+  if (engine.options.auction === AuctionVariant.BidWhileChoosing) {
+    return [...possibleBids(engine, player), chooseFaction];
+  }
+  return [chooseFaction];
+}
+
+export function choosableFactions(engine: Engine) {
   if (engine.randomFactions) {
     if (engine.options.auction && engine.options.auction !== AuctionVariant.ChooseBid) {
       // In auction the player can pick from the pool of random factions
@@ -980,24 +992,8 @@ export function remainingFactions(engine: Engine) {
     }
   } else {
     // Standard
-    return difference(
-      Object.values(Faction),
-      engine.setup.map((f) => f),
-      engine.setup.map((f) => oppositeFaction(f))
-    );
+    return remainingFactions(engine.setup);
   }
-}
-
-function chooseFactionOrBid(engine: Engine, player: Player): AvailableCommand<Command.Bid | Command.ChooseFaction>[] {
-  const chooseFaction: AvailableCommand<Command.Bid | Command.ChooseFaction> = {
-    name: Command.ChooseFaction,
-    player,
-    data: remainingFactions(engine),
-  };
-  if (engine.options.auction === AuctionVariant.BidWhileChoosing) {
-    return [...possibleBids(engine, player), chooseFaction];
-  }
-  return [chooseFaction];
 }
 
 function possibleBids(engine: Engine, player: Player): AvailableCommand<Command.Bid>[] {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -10,7 +10,6 @@ import AvailableCommand, {
   BrainstoneActionData,
   generate as generateAvailableCommands,
   Offer,
-  remainingFactions,
 } from "./available-command";
 import { stdBuildingValue } from "./buildings";
 import {
@@ -39,6 +38,7 @@ import {
   TechTilePos,
 } from "./enums";
 import Event, { EventSource } from "./events";
+import { remainingFactions } from "./factions";
 import SpaceMap, { MapConfiguration } from "./map";
 import Player from "./player";
 import PlayerData, { BrainstoneDest, MoveTokens } from "./player-data";
@@ -1456,7 +1456,7 @@ export default class Engine {
       const randomFactions = [];
 
       for (const _ of this.players) {
-        const possible = remainingFactions({ ...this, setup: randomFactions });
+        const possible = remainingFactions(randomFactions);
 
         randomFactions.push(possible[Math.floor(possible.length * this.map.rng())]);
       }

--- a/engine/src/factions.spec.ts
+++ b/engine/src/factions.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
 import Engine from "./engine";
 import { Faction, Player as PlayerEnum } from "./enums";
-import { oppositeFaction } from "./factions";
+import { remainingFactions } from "./factions";
 
 describe("Factions", () => {
-  it("lantids should be opposite terrans", () => {
-    expect(oppositeFaction(Faction.Terrans)).to.equal(Faction.Lantids);
+  it("lantids and terrans can not be chosen together", () => {
+    expect(remainingFactions([Faction.Terrans])).to.not.contain(Faction.Lantids);
   });
 
   describe("balanced variant", () => {

--- a/engine/src/factions.ts
+++ b/engine/src/factions.ts
@@ -1,65 +1,52 @@
+import { difference } from "lodash";
 import { Faction, Planet } from "./enums";
 
-const factions: { [key in Faction]: { name: string; planet: Planet } } = {
+const factions: { [key in Faction]: { planet: Planet } } = {
   [Faction.Terrans]: {
-    name: "Terrans",
     planet: Planet.Terra,
   },
   [Faction.Lantids]: {
-    name: "Lantids",
     planet: Planet.Terra,
   },
   [Faction.Xenos]: {
-    name: "Xenos",
     planet: Planet.Desert,
   },
   [Faction.Gleens]: {
-    name: "Gleens",
     planet: Planet.Desert,
   },
   [Faction.Taklons]: {
-    name: "Taklons",
     planet: Planet.Swamp,
   },
   [Faction.Ambas]: {
-    name: "Ambas",
     planet: Planet.Swamp,
   },
   [Faction.HadschHallas]: {
-    name: "Hadsch Hallas",
     planet: Planet.Oxide,
   },
   [Faction.Ivits]: {
-    name: "Ivits",
     planet: Planet.Oxide,
   },
   [Faction.Geodens]: {
-    name: "Geoden",
     planet: Planet.Volcanic,
   },
   [Faction.BalTaks]: {
-    name: "Bal T'aks",
     planet: Planet.Volcanic,
   },
   [Faction.Firaks]: {
-    name: "Firaks",
     planet: Planet.Titanium,
   },
   [Faction.Bescods]: {
-    name: "Bescods",
     planet: Planet.Titanium,
   },
   [Faction.Nevlas]: {
-    name: "Nevlas",
     planet: Planet.Ice,
   },
   [Faction.Itars]: {
-    name: "Itars",
     planet: Planet.Ice,
   },
 } as const;
 
-export function oppositeFaction(faction: Faction): Faction {
+function oppositeFaction(faction: Faction): Faction {
   if (!Object.values(Faction).includes(faction)) {
     return null;
   }
@@ -71,6 +58,14 @@ export function oppositeFaction(faction: Faction): Faction {
   }
 }
 
+export function remainingFactions(chosenFactions: Faction[]) {
+  return difference(
+    Object.values(Faction),
+    chosenFactions.map((f) => f),
+    chosenFactions.map((f) => oppositeFaction(f))
+  );
+}
+
 export function factionPlanet(faction: Faction): Planet {
   const fact = factions[faction];
 
@@ -79,5 +74,3 @@ export function factionPlanet(faction: Faction): Planet {
   }
   return Planet.Lost;
 }
-
-export default factions;

--- a/engine/src/player.ts
+++ b/engine/src/player.ts
@@ -29,7 +29,7 @@ import {
 } from "./enums";
 import Event, { EventSource } from "./events";
 import { factionBoard, FactionBoard, FactionBoardRaw, factionVariantBoard } from "./faction-boards";
-import factions, { factionPlanet } from "./factions";
+import { factionPlanet } from "./factions";
 import { FederationInfo, isOutclassedBy } from "./federation";
 import { GaiaHex } from "./gaia-hex";
 import { IncomeSelection } from "./income";
@@ -293,7 +293,7 @@ export default class Player extends EventEmitter {
         }
       } else {
         // Get the number of terraforming steps to pay discounting terraforming track
-        steps = terraformingStepsRequired(factions[this.faction].planet, targetPlanet);
+        steps = terraformingStepsRequired(factionPlanet(this.faction), targetPlanet);
         const reward = terraformingCost(this.data, steps);
 
         if (reward === null) {

--- a/old-ui/src/components/Building.vue
+++ b/old-ui/src/components/Building.vue
@@ -17,7 +17,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
-import { factions, Faction, Building as BuildingEnum, Planet, factionPlanet } from "@gaia-project/engine";
+import { Faction, Building as BuildingEnum, Planet, factionPlanet } from "@gaia-project/engine";
 import { corners } from "../graphics/hex";
 import Token from "./Token.vue";
 

--- a/old-ui/src/components/Commands.vue
+++ b/old-ui/src/components/Commands.vue
@@ -25,8 +25,8 @@
           :button="{
             command: `${command.name} ${faction}`,
             modal: tooltip(faction),
-            title: factions[faction].name,
-            label: `${factions[faction].name} <i class='planet ${factions[faction].planet}'></i>`,
+            title: factionName(faction),
+            label: `${factionName(faction)} <i class='planet ${factionPlanet(faction)}'></i>`,
           }"
           @trigger="handleCommand"
           :key="faction"
@@ -56,7 +56,6 @@ import { Component, Prop } from "vue-property-decorator";
 import Engine, {
   AvailableCommand,
   Command,
-  factions,
   Building,
   GaiaHex,
   Booster,
@@ -65,12 +64,13 @@ import Engine, {
   Faction,
   SpaceMap,
   Expansion,
+  factionPlanet,
 } from "@gaia-project/engine";
 import MoveButton from "./MoveButton.vue";
 import { buildingName } from "../data/building";
 import { GameContext, ButtonData, HighlightHexData } from "../data";
 import { eventDesc } from "../data/event";
-import { factionDesc } from "../data/factions";
+import { factionDesc, factionName } from "../data/factions";
 
 @Component<Commands>({
   watch: {
@@ -96,7 +96,7 @@ import { factionDesc } from "../data/factions";
         command: `${command.name} ${faction}`,
         label: "Random",
         modal: this.tooltip(faction),
-        title: factions[faction].name,
+        title: factionName(faction),
       };
     },
   },
@@ -143,7 +143,7 @@ export default class Commands extends Vue {
 
   get player(): string {
     if (this.engine.players[this.command.player].faction) {
-      return factions[this.engine.players[this.command.player].faction].name;
+      return factionName(this.engine.players[this.command.player].faction);
     }
     if (this.engine.players[this.command.player].name) {
       return this.engine.players[this.command.player].name;
@@ -171,8 +171,12 @@ export default class Commands extends Vue {
     return this.commandTitles.length === 0 ? ["Your turn"] : this.commandTitles;
   }
 
-  get factions() {
-    return factions;
+  factionName(faction: Faction) {
+    return factionName(faction);
+  }
+
+  factionPlanet(faction: Faction) {
+    return factionPlanet(faction);
   }
 
   updateRandomFaction() {

--- a/old-ui/src/components/FinalScoringTile.vue
+++ b/old-ui/src/components/FinalScoringTile.vue
@@ -21,51 +21,56 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import { tiles, Event, factions, FinalTile, Phase, Player, finalScorings, Faction } from '@gaia-project/engine';
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+import { tiles, Event, FinalTile, Phase, Player, finalScorings, Faction } from "@gaia-project/engine";
 import Token from "./Token.vue";
+import { factionName } from "../data/factions";
 
 @Component<FinalScoringTile>({
   computed: {
-    tooltip () {
+    tooltip() {
       const tile = this.tile;
       const players = this.players;
 
-      return players.map(pl => {
-        const name = pl.faction === "automa" ? "Automa" : factions[pl.faction].name;
-        const points = this.progress(pl);
-        return `- ${name}: ${points}`;
-      }).join('\n');
+      return players
+        .map((pl) => {
+          const name = pl.faction === "automa" ? "Automa" : factionName(pl.faction);
+          const points = this.progress(pl);
+          return `- ${name}: ${points}`;
+        })
+        .join("\n");
     },
 
-    highlighted () {
+    highlighted() {
       return this.$store.state.gaiaViewer.data.phase === Phase.EndGame;
-    }
+    },
   },
 
   components: {
-    Token
-  }
+    Token,
+  },
 })
 export default class FinalScoringTile extends Vue {
   @Prop()
   index: number;
 
-  progress (player: Player) {
-    return (player.faction as Faction | "automa") === "automa" ? finalScorings[this.tile].neutralPlayer : player.progress(this.tile);
+  progress(player: Player) {
+    return (player.faction as Faction | "automa") === "automa"
+      ? finalScorings[this.tile].neutralPlayer
+      : player.progress(this.tile);
   }
 
-  get tile () {
+  get tile() {
     return this.$store.state.gaiaViewer.data.tiles.scorings.final[this.index];
   }
 
-  get content () {
+  get content() {
     return this.tile;
   }
 
-  get players () {
-    const pls = this.$store.state.gaiaViewer.data.players.filter(player => !!player && player.faction);
+  get players() {
+    const pls = this.$store.state.gaiaViewer.data.players.filter((player) => !!player && player.faction);
 
     if (this.$store.state.gaiaViewer.data.players.length === 2) {
       pls.push({ faction: "automa" });
@@ -74,11 +79,11 @@ export default class FinalScoringTile extends Vue {
     return pls;
   }
 
-  tokenX (index: number) {
+  tokenX(index: number) {
     return (index % 2) * 30 + 23;
   }
 
-  tokenY (index: number) {
+  tokenY(index: number) {
     return 25 + (index > 1 ? 17 : 0);
   }
 }

--- a/old-ui/src/components/Game.vue
+++ b/old-ui/src/components/Game.vue
@@ -38,33 +38,37 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import Engine, { Command, Phase, factions, Player, EngineOptions, Expansion } from '@gaia-project/engine';
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+import Engine, { Command, Phase, Player, EngineOptions, Expansion } from "@gaia-project/engine";
 
-import AdvancedLog from './AdvancedLog.vue';
-import Commands from './Commands.vue';
-import Pool from './Pool.vue';
-import PlayerInfo from './PlayerInfo.vue';
-import ResearchBoard from './ResearchBoard.vue';
-import ScoringBoard from './ScoringBoard.vue';
-import SpaceMap from './SpaceMap.vue';
-import TurnOrder from './TurnOrder.vue';
-import { resolve } from 'dns';
+import AdvancedLog from "./AdvancedLog.vue";
+import Commands from "./Commands.vue";
+import Pool from "./Pool.vue";
+import PlayerInfo from "./PlayerInfo.vue";
+import ResearchBoard from "./ResearchBoard.vue";
+import ScoringBoard from "./ScoringBoard.vue";
+import SpaceMap from "./SpaceMap.vue";
+import TurnOrder from "./TurnOrder.vue";
+import { resolve } from "dns";
 
 @Component<Game>({
-  created (this: Game) {
+  created(this: Game) {
     const unsub = this.$store.subscribeAction(({ type, payload }) => {
       if (type === "gaiaViewer/externalData") {
         this.handleData(Engine.fromData(payload));
         return;
       }
       if (type === "gaiaViewer/replayStart") {
-        this.$store.dispatch("gaiaViewer/replayInfo", { start: 1, end: this.engine.moveHistory.length, current: this.engine.moveHistory.length });
+        this.$store.dispatch("gaiaViewer/replayInfo", {
+          start: 1,
+          end: this.engine.moveHistory.length,
+          current: this.engine.moveHistory.length,
+        });
 
         this.replayData = {
           current: this.engine.moveHistory.length,
-          backup: JSON.parse(JSON.stringify(this.engine))
+          backup: JSON.parse(JSON.stringify(this.engine)),
         };
         return;
       }
@@ -80,13 +84,22 @@ import { resolve } from 'dns';
 
         this.replayData.current = dest;
 
-        this.$store.dispatch("gaiaViewer/replayInfo", { start: 1, end: this.replayData.backup.moveHistory.length, current: dest });
+        this.$store.dispatch("gaiaViewer/replayInfo", {
+          start: 1,
+          end: this.replayData.backup.moveHistory.length,
+          current: dest,
+        });
 
         if (dest === current) {
           return;
         }
         if (dest < current) {
-          this.handleData(new Engine(this.replayData.backup.moveHistory.slice(0, dest), { ...this.replayData.backup.options, noFedCheck: true }));
+          this.handleData(
+            new Engine(this.replayData.backup.moveHistory.slice(0, dest), {
+              ...this.replayData.backup.options,
+              noFedCheck: true,
+            })
+          );
           return;
         }
 
@@ -109,8 +122,8 @@ import { resolve } from 'dns';
     ResearchBoard,
     ScoringBoard,
     SpaceMap,
-    TurnOrder
-  }
+    TurnOrder,
+  },
 })
 export default class Game extends Vue {
   public currentMove = "";
@@ -118,24 +131,24 @@ export default class Game extends Vue {
   // When joining a game
   name = "";
 
-  replayData: {current: number; backup: Engine} = null;
+  replayData: { current: number; backup: Engine } = null;
 
   @Prop()
   options: EngineOptions;
 
-  get engine (): Engine {
+  get engine(): Engine {
     return this.$store.state.gaiaViewer.data;
   }
 
-  get ended () {
+  get ended() {
     return this.engine.phase === Phase.EndGame;
   }
 
-  get scoringX () {
+  get scoringX() {
     return this.engine.expansions ? 505 : 385;
   }
 
-  get orderedPlayers () {
+  get orderedPlayers() {
     const engine = this.engine;
 
     if (!engine.round || !engine.turnOrder) {
@@ -148,22 +161,24 @@ export default class Game extends Vue {
     //   turnOrder = turnOrder.slice(turnOrder.indexOf(this.player)).concat(turnOrder.slice(0, turnOrder.indexOf(this.player)));
     // }
 
-    return turnOrder.concat(engine.passedPlayers).map(player => engine.players[player]);
+    return turnOrder.concat(engine.passedPlayers).map((player) => engine.players[player]);
   }
 
-  get canPlay () {
-    return !this.ended && (!this.$store.state.gaiaViewer.player || this.sessionPlayer === this.engine.players[this.player]);
+  get canPlay() {
+    return (
+      !this.ended && (!this.$store.state.gaiaViewer.player || this.sessionPlayer === this.engine.players[this.player])
+    );
   }
 
-  get hasMap () {
+  get hasMap() {
     return !!this.$store.state.gaiaViewer.data.map;
   }
 
-  get player () {
+  get player() {
     return this.engine.availableCommands?.[0]?.player;
   }
 
-  get sessionPlayer () {
+  get sessionPlayer() {
     const player = this.$store.state.gaiaViewer.player;
     if (player) {
       if (player.index !== undefined) {
@@ -172,14 +187,14 @@ export default class Game extends Vue {
     }
   }
 
-  handleData (data: Engine, keepMoveHistory?: boolean) {
+  handleData(data: Engine, keepMoveHistory?: boolean) {
     console.log("handle data", keepMoveHistory);
 
-    for (const sector of document.getElementsByClassName('sector') as any as Element[]) {
+    for (const sector of (document.getElementsByClassName("sector") as any) as Element[]) {
       sector.classList.add("notransition");
     }
 
-    this.$store.commit('gaiaViewer/receiveData', data);
+    this.$store.commit("gaiaViewer/receiveData", data);
 
     this.clearCurrentMove = false;
 
@@ -190,13 +205,13 @@ export default class Game extends Vue {
     }
 
     setTimeout(() => {
-      for (const sector of document.getElementsByClassName('sector') as any as Element[]) {
+      for (const sector of (document.getElementsByClassName("sector") as any) as Element[]) {
         sector.classList.remove("notransition");
       }
     });
   }
 
-  handleCommand (command: string) {
+  handleCommand(command: string) {
     if (command.startsWith(Command.Init) || this.engine.round <= 0) {
       this.addMove(command);
       return;
@@ -217,7 +232,7 @@ export default class Game extends Vue {
     }
   }
 
-  undoMove () {
+  undoMove() {
     if (this.currentMove.includes(".")) {
       this.currentMove = this.currentMove.slice(0, this.currentMove.lastIndexOf("."));
     } else {
@@ -226,24 +241,24 @@ export default class Game extends Vue {
     this.addMove(this.currentMove);
   }
 
-  addMove (command: string) {
+  addMove(command: string) {
     this.$store.commit("gaiaViewer/clearContext");
     this.$store.dispatch("gaiaViewer/move", command);
   }
 
-  parseMove (command: string): {player: string; command: string; args: string[]} {
+  parseMove(command: string): { player: string; command: string; args: string[] } {
     command = command.trim();
 
-    if (command.includes('.')) {
-      return this.parseMove(command.slice(0, command.indexOf('.')));
+    if (command.includes(".")) {
+      return this.parseMove(command.slice(0, command.indexOf(".")));
     }
 
-    const split = command.split(' ');
+    const split = command.split(" ");
 
     return {
       player: split[0],
       command: split[1],
-      args: split.slice(2)
+      args: split.slice(2),
     };
   }
 }

--- a/old-ui/src/components/Planet.vue
+++ b/old-ui/src/components/Planet.vue
@@ -10,7 +10,7 @@
 import Vue from "vue";
 import planets from "../data/planets";
 import { Component, Prop } from "vue-property-decorator";
-import { Planet as PlanetEnum, factions, Faction, factionPlanet } from "@gaia-project/engine";
+import { Planet as PlanetEnum, Faction, factionPlanet } from "@gaia-project/engine";
 
 @Component
 export default class Planet extends Vue {

--- a/old-ui/src/components/PlayerBoard/Info.vue
+++ b/old-ui/src/components/PlayerBoard/Info.vue
@@ -85,15 +85,24 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import Resource from '../Resource.vue';
-import { Building as BuildingEnum, Faction, Reward, Operator, Resource as ResourceEnum, factions, PlayerData, Player } from '@gaia-project/engine';
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+import Resource from "../Resource.vue";
+import {
+  Building as BuildingEnum,
+  Faction,
+  Reward,
+  Operator,
+  Resource as ResourceEnum,
+  PlayerData,
+  Player,
+} from "@gaia-project/engine";
+import { factionName } from "../../data/factions";
 
 @Component({
   components: {
-    Resource
-  }
+    Resource,
+  },
 })
 export default class BuildingGroup extends Vue {
   @Prop()
@@ -105,12 +114,12 @@ export default class BuildingGroup extends Vue {
   @Prop()
   player: Player;
 
-  get factionName (): string {
-    return factions[this.faction].name;
+  get factionName(): string {
+    return factionName(this.faction);
   }
 
-  income (resource: ResourceEnum) {
-    const index = this.player.income.search(new RegExp('[0-9]+' + resource));
+  income(resource: ResourceEnum) {
+    const index = this.player.income.search(new RegExp("[0-9]+" + resource));
 
     if (index < 0) {
       return 0;

--- a/old-ui/src/components/PlayerBoard/PowerBowls.vue
+++ b/old-ui/src/components/PlayerBoard/PowerBowls.vue
@@ -35,15 +35,23 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import Resource from '../Resource.vue';
-import { Faction, Reward, FactionBoard, Operator, Resource as ResourceEnum, factions, PlayerData, Player } from '@gaia-project/engine';
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+import Resource from "../Resource.vue";
+import {
+  Faction,
+  Reward,
+  FactionBoard,
+  Operator,
+  Resource as ResourceEnum,
+  PlayerData,
+  Player,
+} from "@gaia-project/engine";
 
 @Component({
   components: {
-    Resource
-  }
+    Resource,
+  },
 })
 export default class BuildingGroup extends Vue {
   @Prop()
@@ -55,28 +63,28 @@ export default class BuildingGroup extends Vue {
   @Prop()
   player: Player;
 
-  get r () {
+  get r() {
     return 2;
   }
 
-  get spacing () {
+  get spacing() {
     return 1.1;
   }
 
-  get sin60 () {
+  get sin60() {
     return 0.86602540378;
   }
 
-  get isTerran () {
+  get isTerran() {
     return this.faction === Faction.Terrans;
   }
 
-  power (area: string) {
+  power(area: string) {
     return this.data.power[area] + (this.data.brainstone === area ? "(b)" : "");
   }
 
-  income (resource: ResourceEnum) {
-    const index = this.player.income.search(new RegExp('[0-9]+' + resource));
+  income(resource: ResourceEnum) {
+    const index = this.player.income.search(new RegExp("[0-9]+" + resource));
 
     if (index < 0) {
       return 0;

--- a/old-ui/src/components/PlayerInfo.vue
+++ b/old-ui/src/components/PlayerInfo.vue
@@ -139,18 +139,18 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import { Player, factions, tiles, PlayerData, Planet, Federation, terraformingStepsRequired, Building, Condition } from '@gaia-project/engine';
-import { factionColor } from '../graphics/utils';
-import TechTile from './TechTile.vue';
-import Booster from './Booster.vue';
-import SpecialAction from './SpecialAction.vue';
-import FederationTile from './FederationTile.vue';
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+import { Player, Planet, factionPlanet } from "@gaia-project/engine";
+import { factionColor } from "../graphics/utils";
+import TechTile from "./TechTile.vue";
+import Booster from "./Booster.vue";
+import SpecialAction from "./SpecialAction.vue";
+import FederationTile from "./FederationTile.vue";
 import BuildingGroup from "./PlayerBoard/BuildingGroup.vue";
 import PlayerBoardInfo from "./PlayerBoard/Info.vue";
-import PowerBowls from './PlayerBoard/PowerBowls.vue';
-import { factionDesc, planetsWithSteps } from '../data/factions';
+import PowerBowls from "./PlayerBoard/PowerBowls.vue";
+import { factionDesc, planetsWithSteps } from "../data/factions";
 
 @Component({
   components: {
@@ -160,64 +160,64 @@ import { factionDesc, planetsWithSteps } from '../data/factions';
     FederationTile,
     BuildingGroup,
     PowerBowls,
-    PlayerBoardInfo
-  }
+    PlayerBoardInfo,
+  },
 })
 export default class PlayerInfo extends Vue {
   @Prop()
   player: Player;
 
-  get playerData () {
+  get playerData() {
     return this.player ? this.player.data : null;
   }
 
-  playerClick (player: Player) {
+  playerClick(player: Player) {
     this.$store.dispatch("gaiaViewer/playerClick", player);
   }
 
-  get factionColor () {
+  get factionColor() {
     return factionColor(this.player.faction);
   }
 
-  get name () {
+  get name() {
     if (this.player.name) {
       return this.player.name;
     }
     return "Player " + (this.player.player + 1);
   }
 
-  get tooltip () {
+  get tooltip() {
     return factionDesc(this.player.faction);
   }
 
-  get planet () {
-    return factions[this.player.faction].planet;
+  get planet() {
+    return factionPlanet(this.player.faction);
   }
 
-  get factionName (): string {
-    return factions[this.player.faction].name;
+  get factionName(): string {
+    return factionPlanet(this.player.faction);
   }
 
-  planetFill (planet: string) {
+  planetFill(planet: string) {
     if (planet === Planet.Titanium || planet === Planet.Swamp) {
       return "white";
     }
     return "black";
   }
 
-  planetsWithSteps (steps: number) {
+  planetsWithSteps(steps: number) {
     return planetsWithSteps(this.planet, steps);
   }
 
-  get passed () {
+  get passed() {
     return (this.$store.state.gaiaViewer.data.passedPlayers || []).includes(this.player.player);
   }
 
-  get round () {
+  get round() {
     return this.$store.state.gaiaViewer.data.round;
   }
 
-  get hasPlanets () {
+  get hasPlanets() {
     return this.player.ownedPlanets.length > 0;
   }
 }

--- a/old-ui/src/components/SpaceHex.vue
+++ b/old-ui/src/components/SpaceHex.vue
@@ -51,7 +51,6 @@ import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import {
   GaiaHex,
-  factions,
   Building as BuildingEnum,
   Planet as PlanetEnum,
   SpaceMap as ISpaceMap,

--- a/old-ui/src/components/Token.vue
+++ b/old-ui/src/components/Token.vue
@@ -7,7 +7,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
-import { factions, Faction, Planet, factionPlanet } from "@gaia-project/engine";
+import { Faction, Planet, factionPlanet } from "@gaia-project/engine";
 
 @Component
 export default class PlayerToken extends Vue {

--- a/old-ui/src/components/TurnOrder.vue
+++ b/old-ui/src/components/TurnOrder.vue
@@ -35,7 +35,7 @@
 </template>
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from "vue-property-decorator";
-import Engine, { factions, Player, Planet, Phase, factionPlanet } from "@gaia-project/engine";
+import Engine, { Player, Planet, Phase, factionPlanet } from "@gaia-project/engine";
 
 @Component
 export default class TurnOrder extends Vue {

--- a/old-ui/src/data/factions.ts
+++ b/old-ui/src/data/factions.ts
@@ -2,51 +2,59 @@ import {
   Building,
   Faction,
   factionBoard,
-  factions,
+  factionPlanet,
   Operator,
   Planet,
   terraformingStepsRequired,
 } from "@gaia-project/engine";
 
-const factionData: { [faction in Faction]: { ability: string; PI: string } } = {
+const factionData: { [faction in Faction]: { name: string; ability: string; PI: string } } = {
   [Faction.Terrans]: {
+    name: "Terrans",
     ability:
       "During the Gaia phase, move the power tokens in your Gaia area to area II of your power cycle instead of to area I.",
     PI:
       "During the Gaia phase, when you move power tokens from your Gaia area to area II of your power cycle, you may gain resources as if you were spending that much power to take free actions.",
   },
   [Faction.Lantids]: {
+    name: "Lantids",
     ability:
       "When you take the Build a Mine action, you may build a mine on a planet colonized by an opponent (including the Lost Planet). Place your mine next to the opponent’s structure. You do not have to pay for terraforming, but you must still pay the mine’s cost. This mine counts as a normal mine in all ways except the following: this mine cannot be upgraded, and it does not count for any effects that relate to how many planet types or Gaia planets you have colonized.",
     PI: "Each time you build a mine on a planet colonized by an opponent, gain two knowledge.",
   },
   [Faction.Xenos]: {
+    name: "Xenos",
     ability: "You place a third starting mine after all other starting mines have been placed.",
     PI:
       "You can form federations with a total power value of six instead of seven. You gain one Q.I.C. as income instead of one power token.",
   },
   [Faction.Gleens]: {
+    name: "Gleens",
     ability:
       "If you would ever gain Q.I.C., gain that much ore instead; once you have upgraded to the second academy, this effect no longer applies. To make a Gaia Planet habitable, pay one ore instead of one Q.I.C. Each time you build a mine on a Gaia Planet, gain two additional VP.",
     PI:
       "When you upgrade to the planetary institute, immediately gain the Gleens’ federation token (2 credits, 1 ore, 1 knowledge). Gaining this tile counts as forming a federation. The planetary institute itself can still be part of a federation on the board.",
   },
   [Faction.Taklons]: {
+    name: "Taklons",
     ability:
       "The Brainstone counts as one power token (when starting a Gaia Project, building satellites, etc.), but you can spend it as if it were three power.",
     PI:
       "Each time you would charge power from “Passive Action: Charge Power,” you gain one power token. You can choose to gain the power before or after charging.",
   },
   [Faction.Ambas]: {
+    name: "Ambas",
     ability: "-",
     PI:
       "Once per round, as an action, you can swap your planetary institute with one of your mines on the game board (this can help you form a new federation). This has no impact on existing federations, even if their power value becomes less than seven. The swap does not count as a build or upgrade action; no VP or power can be gained from it.",
   },
   [Faction.HadschHallas]: {
+    name: "Hadsch Hallas",
     ability: "-",
     PI: "You can spend credits instead of power to take free actions that allow you to gain resources.",
   },
   [Faction.Ivits]: {
+    name: "Ivits",
     ability: `During setup, do not place mines. Instead, after all other players have placed mines (including the Xenos’ third mine), place your planetary institute on any red planet.
     You can have only one federation during the whole game, but unlike other factions, you will be able to grow that federation to gain new federation tokens. After you have formed a federation,
     to take the “Form a Federation” action again, you must connect planets to that federation instead of forming a new federation. The power values of the structures on those planets must bring the total power value of that federation to at least to 7X, where X is the number of federation tokens you own plus one (not including the federation token from level 5 of “Terraforming”). All other rules for forming a federation apply, including building satellites and gaining federation tokens. To build a satellite during this action, you must spend one Q.I.C. instead of discarding one power.`,
@@ -58,21 +66,25 @@ const factionData: { [faction in Faction]: { ability: string; PI: string } } = {
     Your opponents can place satellites in a space containing a space station.`,
   },
   [Faction.Geodens]: {
+    name: "Geoden",
     ability: "-",
     PI:
       "The first time you build a mine on each planet type, gain 3 knowledge. (You do not gain knowledge for planet types you colonized before upgrading to your planetary institute.)",
   },
   [Faction.BalTaks]: {
+    name: "Bal T'aks",
     ability: `You cannot advance in the “Navigation” research area, even if you take the tech tile below the “Navigation” research area. If you do take that tech tile, no advancement occurs.
     As a free action, you can move a Gaiaformer from a Gaiaformer space on your faction board to your Gaia area to gain one Q.I.C. Gaiaformers in your Gaia area are not available until the next Gaia phase. In the next Gaia phase, move any Gaiaformer in your Gaia area back to its Gaiaformer space.`,
     PI: "You can now advance in the “Navigation” research area.",
   },
   [Faction.Firaks]: {
+    name: "Firaks",
     ability: "-",
     PI:
       "As an action, you can “downgrade” a research lab into a trading station and immediately advance one level in a research area of your choice. This counts as an “Upgrade to a Trading Station” action. You can later upgrade the trading station back into a research lab using the normal rules (including gaining a new tech tile).",
   },
   [Faction.Bescods]: {
+    name: "Bescods",
     ability: `The positions of your planetary institute and academies are swapped on your faction board, as is the income you gain for trading stations and research labs. As with the other factions, upgrading to an academy or a research lab allows you to gain a tech tile.
     Once per round, as an action, you can advance your lowest-level token in a research area (without paying knowledge). If multiple of your tokens are tied for the lowest level, choose which of
     the tied tokens to advance. To advance to level 5 this way, you must still flip a federation token as normal. Remember, only one player can reach level 5 of each research area.`,
@@ -80,12 +92,14 @@ const factionData: { [faction in Faction]: { ability: string; PI: string } } = {
       "The power value of your structures on gray planets (your home type) is increased by one (in addition to any other effects that increase their power value).",
   },
   [Faction.Nevlas]: {
+    name: "Nevlas",
     ability:
       "As a free action, you can move one power token from area III of your power cycle to your Gaia area to gain one knowledge (these power tokens follow the normal Gaia phase rules). This does not count as spending power.",
     PI:
       "You can spend power tokens in area III of your power cycle as if they were each two power. Otherwise, they count as one power token (when starting a Gaia Project, building satellites, etc.). When paying for a power action with an odd power cost (1, 3, 5, etc.), the unspent power is lost.",
   },
   [Faction.Itars]: {
+    name: "Itars",
     ability:
       "Each time you discard a power token from area II of your power cycle to move another power token to area III, place the discarded power token in your Gaia area instead of returning it to the supply.",
     PI: `During the Gaia phase, you can discard 4 power tokens from your Gaia area to immediately gain a tech tile. You may do this as many times as you can afford to.`,
@@ -106,7 +120,7 @@ export function planetsWithSteps(planet: Planet, steps: number) {
 
 export function factionDesc(faction: Faction) {
   const board = factionBoard(faction);
-  const p = factions[faction].planet;
+  const p = factionPlanet(faction);
 
   const buildingDesc =
     "<ul>" +
@@ -152,4 +166,8 @@ export function factionDesc(faction: Faction) {
     </span>
   </div>
   `;
+}
+
+export function factionName(faction: Faction) {
+  return factionData[faction].name;
 }

--- a/old-ui/src/graphics/utils.ts
+++ b/old-ui/src/graphics/utils.ts
@@ -1,6 +1,6 @@
-import { Faction, factions } from "@gaia-project/engine";
+import { Faction, factionPlanet } from "@gaia-project/engine";
 import planets from "../data/planets";
 
 export function factionColor(faction: Faction): string {
-  return planets[factions[faction].planet].color;
+  return planets[factionPlanet(faction)].color;
 }

--- a/viewer/src/components/BoardAction.vue
+++ b/viewer/src/components/BoardAction.vue
@@ -53,27 +53,26 @@ import Engine, {
   BoardAction as BoardActionEnum,
   boardActions,
   Command,
+  factionPlanet,
   Planet,
   PlayerEnum,
 } from "@gaia-project/engine";
 import Resource from "./Resource.vue";
 import SpecialAction from "./SpecialAction.vue";
-import { factionPlanet } from "@gaia-project/engine/src/factions";
 import { boardActionButton } from "../logic/commands";
 
 @Component<BoardAction>({
   components: {
     Resource,
-    SpecialAction
+    SpecialAction,
   },
 })
 export default class BoardAction extends Vue {
-
   @Prop()
   action: BoardActionEnum;
 
   @Prop()
-  transform: string
+  transform: string;
 
   onClick() {
     if (!this.highlighted) {
@@ -88,7 +87,7 @@ export default class BoardAction extends Vue {
 
   get recent(): boolean {
     const moves = this.$store.getters["gaiaViewer/recentCommands"];
-    return moves.some((c) => c.command == Command.Action && c.args[0] as BoardActionEnum === this.action);
+    return moves.some((c) => c.command == Command.Action && (c.args[0] as BoardActionEnum) === this.action);
   }
 
   get button() {

--- a/viewer/src/components/Commands.vue
+++ b/viewer/src/components/Commands.vue
@@ -41,8 +41,8 @@
           :button="{
             command: `${factionsToChoose.name} ${faction}`,
             modal: modalDialog(tooltip(faction)),
-            title: factions[faction].name,
-            label: `${factions[faction].name} <i class='planet ${factions[faction].planet}'></i>`,
+            title: factionName(faction),
+            label: `${factionName(faction)} <i class='planet ${factionPlanet(faction)}'></i>`,
             shortcuts: [factionShortcut(faction)],
           }"
           @trigger="handleCommand"
@@ -67,7 +67,7 @@ import Engine, {
   BuildWarning,
   Command,
   Faction,
-  factions,
+  factionPlanet,
   GaiaHex,
   Resource,
   Reward,
@@ -77,7 +77,7 @@ import Engine, {
 } from "@gaia-project/engine";
 import MoveButton from "./MoveButton.vue";
 import { ButtonData, GameContext, ModalButtonData } from "../data";
-import { factionDesc, factionShortcut } from "../data/factions";
+import { factionDesc, factionName, factionShortcut } from "../data/factions";
 import { FactionCustomization } from "@gaia-project/engine/src/engine";
 import { factionVariantBoard } from "@gaia-project/engine/src/faction-boards";
 import { moveWarnings } from "../data/warnings";
@@ -86,15 +86,20 @@ import {
   boardActionsButton,
   brainstoneButtons,
   buildButtons,
-  chargePowerButtons, deadEndButton, declineButton,
+  chargePowerButtons,
+  deadEndButton,
+  declineButton,
   endTurnButton,
-  fastConversionClick, federationButton, federationTypeButtons,
+  fastConversionClick,
+  federationButton,
+  federationTypeButtons,
   finalizeShortcuts,
   freeAndBurnButton,
   hexMap,
   passButtons,
   researchButtons,
-  specialActionsButton, UndoPropagation,
+  specialActionsButton,
+  UndoPropagation,
 } from "../logic/commands";
 import Undo from "./Resources/Undo.vue";
 
@@ -119,9 +124,9 @@ let show = false;
         },
         canActivate() {
           return !show;
-        }
+        },
       };
-    }
+    },
   },
   computed: {
     randomFactionButton() {
@@ -134,7 +139,7 @@ let show = false;
         label: "Random",
         shortcuts: ["r"],
         modal: this.modalDialog(this.tooltip(faction)),
-        title: factions[faction].name,
+        title: factionName(faction),
       };
     },
   },
@@ -220,7 +225,7 @@ export default class Commands extends Vue {
 
   get playerName(): string {
     if (this.player.faction) {
-      return factions[this.player.faction].name;
+      return factionName(this.player.faction);
     }
     if (this.player.name) {
       return this.player.name;
@@ -253,11 +258,15 @@ export default class Commands extends Vue {
   }
 
   get warnings(): string[] {
-    return this.currentMoveWarnings?.map(w => moveWarnings[w].text) ?? [];
+    return this.currentMoveWarnings?.map((w) => moveWarnings[w].text) ?? [];
   }
 
-  get factions() {
-    return factions;
+  factionName(faction: Faction) {
+    return factionName(faction);
+  }
+
+  factionPlanet(faction: Faction) {
+    return factionPlanet(faction);
   }
 
   factionShortcut(faction: Faction) {
@@ -470,8 +479,8 @@ export default class Commands extends Vue {
             buttons: federationTypeButtons(command.data.tiles, this.player),
           });
           break;
+        }
       }
-    }
     }
 
     if (conversions.free || conversions.burn) {
@@ -494,7 +503,7 @@ export default class Commands extends Vue {
 
       this.$store.commit("gaiaViewer/fastConversionTooltips", d.tooltips);
       // tooltips may have become unavailable - and they should be hidden
-      this.$root.$emit('bv::hide::tooltip');
+      this.$root.$emit("bv::hide::tooltip");
     }
 
     if (this.customButtons.length > 0) {

--- a/viewer/src/components/FactionWheel.vue
+++ b/viewer/src/components/FactionWheel.vue
@@ -29,7 +29,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component } from "vue-property-decorator";
-import Engine, { factions, Planet } from "@gaia-project/engine";
+import Engine, { factionPlanet, Planet } from "@gaia-project/engine";
 
 @Component
 export default class FactionWheel extends Vue {
@@ -48,7 +48,7 @@ export default class FactionWheel extends Vue {
 
   strokeWidth(pos: number) {
     const planet = this.planet(pos);
-    if (this.gameData.players.some((p) => p.faction && factions[p.faction].planet === planet)) {
+    if (this.gameData.players.some((p) => p.faction && factionPlanet(p.faction) === planet)) {
       return "0.2px; stroke-dasharray:.5 .2";
     }
 
@@ -73,7 +73,7 @@ export default class FactionWheel extends Vue {
       const faction = data.player(player)?.faction;
       if (faction != null) {
         // own faction - or current players faction - should be at the top
-        const planet = factions[faction].planet;
+        const planet = factionPlanet(faction);
         const offset = list.indexOf(planet);
         return list[(pos + offset) % 7];
       }

--- a/viewer/src/components/FinalScoringTile.vue
+++ b/viewer/src/components/FinalScoringTile.vue
@@ -28,8 +28,9 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
-import { tiles, Event, factions, FinalTile, Phase, Player, finalScorings, Faction } from "@gaia-project/engine";
+import { Phase, Player, finalScorings, Faction } from "@gaia-project/engine";
 import Token from "./Token.vue";
+import { factionName } from "../data/factions";
 
 @Component<FinalScoringTile>({
   computed: {
@@ -39,7 +40,7 @@ import Token from "./Token.vue";
 
       return players
         .map((pl) => {
-          const name = pl.faction === "automa" ? "Automa" : factions[pl.faction].name;
+          const name = pl.faction === "automa" ? "Automa" : factionName(pl.faction);
           const points = this.progress(pl);
           return `- ${name}: ${points}`;
         })

--- a/viewer/src/components/Planet.vue
+++ b/viewer/src/components/Planet.vue
@@ -10,8 +10,7 @@
 import Vue from "vue";
 import planets from "../data/planets";
 import { Component, Prop } from "vue-property-decorator";
-import { Planet as PlanetEnum, factions, Faction } from "@gaia-project/engine";
-import {factionPlanet} from "@gaia-project/engine/src/factions";
+import { Planet as PlanetEnum, factionPlanet, Faction } from "@gaia-project/engine";
 
 @Component
 export default class Planet extends Vue {

--- a/viewer/src/components/PlayerBoard/Info.vue
+++ b/viewer/src/components/PlayerBoard/Info.vue
@@ -115,15 +115,16 @@ import { Component, Prop } from "vue-property-decorator";
 import { uniq } from "lodash";
 import Resource from "../Resource.vue";
 import Undo from "../Resources/Undo.vue";
-import { Faction, factions, Player, PlayerData, ResearchField, Resource as ResourceEnum } from "@gaia-project/engine";
+import { Faction, Player, PlayerData, ResearchField, Resource as ResourceEnum } from "@gaia-project/engine";
 import VictoryPoint from "../Resources/VictoryPoint.vue";
 import { FastConversionEvent } from "../../data/actions";
+import { factionName } from "../../data/factions";
 
 @Component({
   components: {
     Resource,
     VictoryPoint,
-    Undo
+    Undo,
   },
 })
 export default class PlayerBoardInfo extends Vue {
@@ -145,7 +146,7 @@ export default class PlayerBoardInfo extends Vue {
   }
 
   get factionName(): string {
-    return factions[this.faction].name;
+    return factionName(this.faction);
   }
 
   convert(resource: ResourceEnum) {

--- a/viewer/src/components/PlayerInfo.vue
+++ b/viewer/src/components/PlayerInfo.vue
@@ -180,7 +180,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
-import Engine, { Command, factions, Planet, Player } from "@gaia-project/engine";
+import Engine, { factionPlanet, Planet, Player } from "@gaia-project/engine";
 import { factionColor } from "../graphics/utils";
 import TechTile from "./TechTile.vue";
 import Booster from "./Booster.vue";
@@ -189,7 +189,7 @@ import FederationTile from "./FederationTile.vue";
 import BuildingGroup from "./PlayerBoard/BuildingGroup.vue";
 import PlayerBoardInfo from "./PlayerBoard/Info.vue";
 import PowerBowls from "./PlayerBoard/PowerBowls.vue";
-import { factionDesc, planetsWithSteps } from "../data/factions";
+import { factionDesc, factionName, planetsWithSteps } from "../data/factions";
 
 @Component({
   components: {
@@ -234,7 +234,7 @@ export default class PlayerInfo extends Vue {
   }
 
   get planet() {
-    return factions[this.faction].planet;
+    return factionPlanet(this.faction);
   }
 
   get faction() {
@@ -242,7 +242,7 @@ export default class PlayerInfo extends Vue {
   }
 
   get factionName(): string {
-    return factions[this.faction].name;
+    return factionName(this.faction);
   }
 
   recentAction(i: number): boolean {

--- a/viewer/src/components/SpaceHex.vue
+++ b/viewer/src/components/SpaceHex.vue
@@ -58,7 +58,7 @@ import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import Engine, {
   Building as BuildingEnum,
-  factions,
+  factionPlanet,
   GaiaHex,
   Planet as PlanetEnum,
   SpaceMap as ISpaceMap,
@@ -68,9 +68,9 @@ import Planet from "./Planet.vue";
 import Building from "./Building.vue";
 import { buildingName } from "../data/building";
 import { planetNames } from "../data/planets";
-import { factionPlanet } from "@gaia-project/engine/src/factions";
 import { HighlightHexData } from "../data";
 import { moveWarnings } from "../data/warnings";
+import { factionName } from "../data/factions";
 
 @Component<SpaceHex>({
   components: {
@@ -99,7 +99,7 @@ export default class SpaceHex extends Vue {
 
   warning(hex: GaiaHex): string {
     const warnings = this.highlightedHexes.get(hex)?.warnings;
-    return warnings?.length > 0 ? warnings?.map(w => moveWarnings[w].text).join(", ") : null;
+    return warnings?.length > 0 ? warnings?.map((w) => moveWarnings[w].text).join(", ") : null;
   }
 
   cost(hex: GaiaHex) {
@@ -127,8 +127,8 @@ export default class SpaceHex extends Vue {
   }
 
   buildingName(building: BuildingEnum, player) {
-    let f = factions[this.faction(player)];
-    return `${buildingName(building, f)} (${f.name})`;
+    const name = factionName(this.faction(player));
+    return `${buildingName(building, this.faction(player))} (${name})`;
   }
 
   planetName(planet: PlanetEnum) {

--- a/viewer/src/data/factions.ts
+++ b/viewer/src/data/factions.ts
@@ -2,7 +2,7 @@ import {
   Building,
   Faction,
   factionBoard,
-  factions,
+  factionPlanet,
   Operator,
   Planet,
   PowerArea,
@@ -10,8 +10,9 @@ import {
 } from "@gaia-project/engine";
 import { FactionBoardRaw } from "@gaia-project/engine/src/faction-boards";
 
-const factionData: { [faction in Faction]: { ability: string; PI: string; shortcut: string } } = {
+const factionData: { [faction in Faction]: { name: string; ability: string; PI: string; shortcut: string } } = {
   [Faction.Terrans]: {
+    name: "Terrans",
     ability:
       "During the Gaia phase, move the power tokens in your Gaia area to area II of your power cycle instead of to area I.",
     PI:
@@ -19,18 +20,21 @@ const factionData: { [faction in Faction]: { ability: string; PI: string; shortc
     shortcut: "t",
   },
   [Faction.Lantids]: {
+    name: "Lantids",
     ability:
       "When you take the Build a Mine action, you may build a mine on a planet colonized by an opponent (including the Lost Planet). Place your mine next to the opponent’s structure. You do not have to pay for terraforming, but you must still pay the mine’s cost. This mine counts as a normal mine in all ways except the following: this mine cannot be upgraded, and it does not count for any effects that relate to how many planet types or Gaia planets you have colonized.",
     PI: "Each time you build a mine on a planet colonized by an opponent, gain two knowledge.",
     shortcut: "l",
   },
   [Faction.Xenos]: {
+    name: "Xenos",
     ability: "You place a third starting mine after all other starting mines have been placed.",
     PI:
       "You can form federations with a total power value of six instead of seven. You gain one Q.I.C. as income instead of one power token.",
     shortcut: "x",
   },
   [Faction.Gleens]: {
+    name: "Gleens",
     ability:
       "If you would ever gain Q.I.C., gain that much ore instead; once you have upgraded to the second academy, this effect no longer applies. To make a Gaia Planet habitable, pay one ore instead of one Q.I.C. Each time you build a mine on a Gaia Planet, gain two additional VP.",
     PI:
@@ -38,6 +42,7 @@ const factionData: { [faction in Faction]: { ability: string; PI: string; shortc
     shortcut: "e",
   },
   [Faction.Taklons]: {
+    name: "Taklons",
     ability:
       "The Brainstone counts as one power token (when starting a Gaia Project, building satellites, etc.), but you can spend it as if it were three power.",
     PI:
@@ -45,17 +50,20 @@ const factionData: { [faction in Faction]: { ability: string; PI: string; shortc
     shortcut: "k",
   },
   [Faction.Ambas]: {
+    name: "Ambas",
     ability: "-",
     PI:
       "Once per round, as an action, you can swap your planetary institute with one of your mines on the game board (this can help you form a new federation). This has no impact on existing federations, even if their power value becomes less than seven. The swap does not count as a build or upgrade action; no VP or power can be gained from it.",
     shortcut: "a",
   },
   [Faction.HadschHallas]: {
+    name: "Hadsch Hallas",
     ability: "-",
     PI: "You can spend credits instead of power to take free actions that allow you to gain resources.",
     shortcut: "d",
   },
   [Faction.Ivits]: {
+    name: "Ivits",
     ability: `During setup, do not place mines. Instead, after all other players have placed mines (including the Xenos’ third mine), place your planetary institute on any red planet.
     You can have only one federation during the whole game, but unlike other factions, you will be able to grow that federation to gain new federation tokens. After you have formed a federation,
     to take the “Form a Federation” action again, you must connect planets to that federation instead of forming a new federation. The power values of the structures on those planets must bring the total power value of that federation to at least to 7X, where X is the number of federation tokens you own plus one (not including the federation token from level 5 of “Terraforming”). All other rules for forming a federation apply, including building satellites and gaining federation tokens. To build a satellite during this action, you must spend one Q.I.C. instead of discarding one power.`,
@@ -68,24 +76,28 @@ const factionData: { [faction in Faction]: { ability: string; PI: string; shortc
     shortcut: "v",
   },
   [Faction.Geodens]: {
+    name: "Geoden",
     ability: "-",
     PI:
       "The first time you build a mine on each planet type, gain 3 knowledge. (You do not gain knowledge for planet types you colonized before upgrading to your planetary institute.)",
     shortcut: "o",
   },
   [Faction.BalTaks]: {
+    name: "Bal T'aks",
     ability: `You cannot advance in the “Navigation” research area, even if you take the tech tile below the “Navigation” research area. If you do take that tech tile, no advancement occurs.
     As a free action, you can move a Gaiaformer from a Gaiaformer space on your faction board to your Gaia area to gain one Q.I.C. Gaiaformers in your Gaia area are not available until the next Gaia phase. In the next Gaia phase, move any Gaiaformer in your Gaia area back to its Gaiaformer space.`,
     PI: "You can now advance in the “Navigation” research area.",
     shortcut: "'",
   },
   [Faction.Firaks]: {
+    name: "Firaks",
     ability: "-",
     PI:
       "As an action, you can “downgrade” a research lab into a trading station and immediately advance one level in a research area of your choice. This counts as an “Upgrade to a Trading Station” action. You can later upgrade the trading station back into a research lab using the normal rules (including gaining a new tech tile).",
     shortcut: "f",
   },
   [Faction.Bescods]: {
+    name: "Bescods",
     ability: `The positions of your planetary institute and academies are swapped on your faction board, as is the income you gain for trading stations and research labs. As with the other factions, upgrading to an academy or a research lab allows you to gain a tech tile.
     Once per round, as an action, you can advance your lowest-level token in a research area (without paying knowledge). If multiple of your tokens are tied for the lowest level, choose which of
     the tied tokens to advance. To advance to level 5 this way, you must still flip a federation token as normal. Remember, only one player can reach level 5 of each research area.`,
@@ -94,6 +106,7 @@ const factionData: { [faction in Faction]: { ability: string; PI: string; shortc
     shortcut: "c",
   },
   [Faction.Nevlas]: {
+    name: "Nevlas",
     ability:
       "As a free action, you can move one power token from area III of your power cycle to your Gaia area to gain one knowledge (these power tokens follow the normal Gaia phase rules). This does not count as spending power.",
     PI:
@@ -101,6 +114,7 @@ const factionData: { [faction in Faction]: { ability: string; PI: string; shortc
     shortcut: "n",
   },
   [Faction.Itars]: {
+    name: "Itars",
     ability:
       "Each time you discard a power token from area II of your power cycle to move another power token to area III, place the discarded power token in your Gaia area instead of returning it to the supply.",
     PI: `During the Gaia phase, you can discard 4 power tokens from your Gaia area to immediately gain a tech tile. You may do this as many times as you can afford to.`,
@@ -126,7 +140,7 @@ export function factionShortcut(faction: Faction): string {
 
 export function factionDesc(faction: Faction, variant?: FactionBoardRaw) {
   const board = factionBoard(faction, variant);
-  const p = factions[faction].planet;
+  const p = factionPlanet(faction);
 
   const buildingDesc =
     "<ul>" +
@@ -175,4 +189,8 @@ export function factionDesc(faction: Faction, variant?: FactionBoardRaw) {
     </span>
   </div>
   `;
+}
+
+export function factionName(faction: Faction) {
+  return factionData[faction].name;
 }

--- a/viewer/src/graphics/utils.ts
+++ b/viewer/src/graphics/utils.ts
@@ -1,12 +1,11 @@
-import { Faction, factions, Planet } from "@gaia-project/engine";
-import { factionPlanet } from "@gaia-project/engine/src/factions";
+import { Faction, factionPlanet, Planet } from "@gaia-project/engine";
 import planets from "../data/planets";
 
 export function factionColor(faction: Faction | "gen"): string {
   if (faction === "gen") {
     return "#d3d3d3";
   }
-  return planets[factions[faction].planet].color;
+  return planets[factionPlanet(faction)].color;
 }
 
 export function planetColor(planet: Exclude<Planet, Planet.Empty>): string {
@@ -60,19 +59,19 @@ export function lightenDarkenColor(col: string, amt: number) {
 
 function newPlanetColors(amt: number) {
   return Object.fromEntries(
-    Object.entries(factions).map(([f, c]) => {
-      const planet = c.planet;
+    Object.values(Faction).map((faction) => {
+      const planet = factionPlanet(faction);
       const color = planet == Planet.Ice ? "#000000" : planets[planet].color;
-      return [f, amt == 0 ? color : lightenDarkenColor(color, amt)];
+      return [faction, amt == 0 ? color : lightenDarkenColor(color, amt)];
     })
   );
 }
 
 export const factionLogTextColors = Object.fromEntries(
-  Object.entries(factions).map(([f, c]) => {
-    const planet = c.planet;
+  Object.values(Faction).map((faction) => {
+    const planet = factionPlanet(faction);
     const color = planet == Planet.Ice || planet == Planet.Swamp || planet == Planet.Titanium ? "white" : "black";
-    return [f, color];
+    return [faction, color];
   })
 );
 export const factionLogColors = newPlanetColors(0);

--- a/viewer/src/logic/chart-factory.ts
+++ b/viewer/src/logic/chart-factory.ts
@@ -1,4 +1,4 @@
-import Engine, { factions, Player, PlayerEnum } from "@gaia-project/engine";
+import Engine, { Player, PlayerEnum } from "@gaia-project/engine";
 import {
   ChartConfiguration,
   ChartDataset,
@@ -10,6 +10,7 @@ import {
   TooltipOptions,
 } from "chart.js";
 import { sortBy, sum, sumBy } from "lodash";
+import { factionName } from "../data/factions";
 import {
   ChartColor,
   ChartFamily,
@@ -421,7 +422,7 @@ export function kinds(data: Engine, family: ChartFamily): ChartKindDisplay[][] {
   ];
   const playerDetails: ChartKindDisplay[] = players.map((p) => ({
     kind: p,
-    label: factions[data.player(p).faction].name,
+    label: factionName(data.player(p).faction),
   }));
   const kinds: ChartKindDisplay[] = chartFactory(family)
     .sources(family)

--- a/viewer/src/logic/charts.ts
+++ b/viewer/src/logic/charts.ts
@@ -4,7 +4,7 @@ import Engine, {
   EventSource,
   Faction,
   factionBoard,
-  factions,
+  factionPlanet,
   LogEntry,
   Planet,
   Player,
@@ -12,6 +12,7 @@ import Engine, {
   ResearchField,
   Resource,
 } from "@gaia-project/engine";
+import { factionName } from "../data/factions";
 import { ChartStyleDisplay } from "./chart-factory";
 import { CommandObject, parseCommands } from "./recent";
 import { SimpleSource } from "./simple-charts";
@@ -161,11 +162,11 @@ export function planetColor(planet: Planet, invert: boolean): string {
 }
 
 export function playerColor(pl: Player, invert: boolean): ColorVar {
-  return new ColorVar(planetColor(factions[pl.faction].planet, invert));
+  return new ColorVar(planetColor(factionPlanet(pl.faction), invert));
 }
 
 export function playerLabel(pl: Player) {
-  return factions[pl.faction].name;
+  return factionName(pl.faction);
 }
 
 export function weightedSum(data: Engine, player: PlayerEnum, factories: DatasetFactory[]): DatasetFactory | null {


### PR DESCRIPTION
If we want to build more factions, either as an addition or a replacement, it will be very convenient if the list of factions (most notably when selecting factions) is hidden away.