### PR TITLE
🐛 (engine) Don't allow trading if you can't pay

### DIFF
--- a/engine/src/available/ships.spec.ts
+++ b/engine/src/available/ships.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import Engine from "../engine";
+
+describe("Trade ships", () => {
+  const moves = [
+    "init 2 Pleasant-barrel-3642",
+    "p1 faction ambas",
+    "p2 faction firaks (0/0/0/0 ⇒ 2/4/0/0)",
+    "ambas build m 7B2",
+    "firaks build m 7A6",
+    "firaks build m 2A10",
+    "ambas build m 2B3",
+    "firaks booster booster9",
+    "ambas booster booster5 (2/4/0/0 ⇒ 0/6/0/0)",
+    "ambas build ts 7B2.",
+    "firaks charge 1pw (0/4/2/0 ⇒ 0/3/3/0)",
+    "firaks build tradeShip 7B3.",
+    "ambas pass booster2 returning booster5",
+    "firaks pass booster6 returning booster9",
+    "ambas pass booster9 returning booster2",
+  ];
+
+  it("can trade when the trade cost is fulfilled", () => {
+    const engine = new Engine(moves, { frontiers: true });
+    expect(() => engine.move("firaks move tradeShip 7B3 7B3 trade 7B2.")).to.not.throw();
+  });
+
+  it("can not trade when the trade cost is not fulfilled", () => {
+    const engine = new Engine(moves, { frontiers: true });
+    expect(() =>
+      engine.move("spend 3pw for 1o (0/3/3/0 ⇒ 3/3/0/0). firaks move tradeShip 7B3 7B3 trade 7B2.")
+    ).to.throw();
+  });
+});


### PR DESCRIPTION
If you trade with an opponent's building that is not a mine, 3 pw will be subtracted even if you can't pay it. This will result in tokens appearing out of nowhere and having a negative amount of tokens in area 3.