### PR TITLE
feat: add moveAI for bot players

### DIFF
--- a/engine/index.ts
+++ b/engine/index.ts
@@ -69,6 +69,7 @@ export { factionPlanet } from "./src/factions";
 export { federationCost, FederationInfo, parseFederationLocation } from "./src/federation";
 export { GaiaHex, GaiaHexData } from "./src/gaia-hex";
 export { applyChargePowers } from "./src/income";
+export { moveAI } from "./src/move/ai";
 export { leechPossible } from "./src/move/phase";
 export { planetNames, terraformingStepsRequired } from "./src/planets";
 export { lastTile, researchEvents } from "./src/research-tracks";

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -25,6 +25,7 @@ import Event, { EventSource } from "./events";
 import { factionVariantBoard, latestVariantVersion } from "./faction-boards";
 import SpaceMap, { MapConfiguration } from "./map";
 import { moveAction, moveBurn, movePiSwap, moveSpecial, moveSpend } from "./move/actions";
+import { appendCommand, moveAI as generateAIMove } from "./move/ai";
 import { autoMove } from "./move/auto";
 import { moveBuild, moveLostPlanet } from "./move/buildings";
 import { moveChooseFederationTile, moveFormFederation } from "./move/federation";
@@ -560,6 +561,72 @@ export default class Engine {
   /** Automatically generate moves based on player settings */
   autoMove(partialMove?: string, options?: { autoPass?: boolean }): boolean {
     return autoMove(this, partialMove, options);
+  }
+
+  /**
+   * Execute a random legal move for the current player ("dumb AF" bot, used by
+   * the platform to drive bot players).
+   *
+   * Returns `true` if a move was made, `false` if there is nothing to play (game
+   * ended, no player to move) or if no move could be completed: a random move
+   * can be a dead end (e.g. upgrading a mine with no ore left to rebuild), in
+   * which case the engine is left unchanged.
+   */
+  moveAI(): boolean {
+    if (this.ended || this.playerToMove === undefined) {
+      return false;
+    }
+
+    // Simulate the whole turn on copies: a random move can be a dead end (e.g.
+    // upgrading a mine with no ore left to rebuild), and an incomplete move
+    // cannot be undone. A turn is built as a single dot-separated move - the
+    // only way to execute several commands in one turn. The salt makes each
+    // attempt draw different random choices.
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const move = generateAIMove(this, this.playerToMove, attempt);
+
+      if (!move) {
+        return false;
+      }
+
+      let completed = false;
+
+      // A command can trigger follow-up decisions for the same player (e.g.
+      // choosing a tech tile after building a research lab): keep appending
+      // random commands to the move until the turn is complete
+      let fullMove = move;
+      for (let safeguard = 0; safeguard < 20; safeguard++) {
+        const copy = Engine.fromData(JSON.parse(JSON.stringify(this)));
+
+        try {
+          copy.move(fullMove);
+        } catch {
+          // Illegal or incomplete move
+          break;
+        }
+
+        if (copy.newTurn || copy.ended) {
+          completed = true;
+          break;
+        }
+
+        const command = appendCommand(copy, copy.playerToMove, safeguard);
+        if (!command) {
+          break;
+        }
+
+        // Append to the simulated move; the next iteration re-checks it
+        fullMove = `${fullMove}. ${command}`;
+      }
+
+      if (completed) {
+        // The turn can be completed: replay it on the real engine
+        this.move(fullMove);
+        return true;
+      }
+    }
+
+    return false;
   }
 
   static fromData(data: Record<string, any>): Engine {

--- a/engine/src/move/ai.spec.ts
+++ b/engine/src/move/ai.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import Engine from "../engine";
+import { Phase, Player as PlayerEnum } from "../enums";
+import { moveAI } from "./ai";
+
+describe("moveAI", () => {
+  it("should generate a legal faction move", () => {
+    const engine = new Engine(["init 2 randomSeed"]);
+
+    const move = moveAI(engine, engine.playerToMove);
+
+    expect(/^p1 faction /.test(move)).to.be.true;
+    expect(() => engine.move(move)).to.not.throw();
+  });
+
+  it("should not generate a move when there is no player to move", () => {
+    const engine = new Engine();
+
+    expect(moveAI(engine, PlayerEnum.Player1)).to.equal(null);
+    expect(engine.moveAI()).to.be.false;
+  });
+
+  it("should make a move through the engine method", () => {
+    const engine = new Engine(["init 2 randomSeed"]);
+
+    expect(engine.moveAI()).to.be.true;
+    expect(engine.moveHistory.length).to.equal(2);
+    expect(engine.playerToMove).to.equal(PlayerEnum.Player2);
+  });
+
+  it("should be deterministic for a given seed", () => {
+    const run = () => {
+      const engine = new Engine(["init 2 randomSeed"]);
+      for (let i = 0; i < 30 && !engine.ended; i++) {
+        engine.moveAI();
+        // auto-charge free leech decisions of the other players
+        while (engine.autoMove()) {
+          // process all forced moves
+        }
+      }
+      return engine.moveHistory;
+    };
+
+    expect(run()).to.deep.equal(run());
+  });
+
+  it("should let a bot complete the setup phase", () => {
+    const engine = new Engine(["init 2 randomSeed"]);
+
+    let moves = 0;
+    while (engine.phase !== Phase.RoundMove && moves < 100) {
+      expect(engine.moveAI(), `stuck in phase ${engine.phase}`).to.be.true;
+      moves++;
+    }
+
+    expect(engine.phase).to.equal(Phase.RoundMove);
+  });
+
+  it("should let bots play a full game until the end", function () {
+    this.timeout(60000);
+
+    const engine = new Engine(["init 2 randomSeed"]);
+
+    let moves = 0;
+    while (!engine.ended && moves < 2000) {
+      const progressed =
+        // auto-charge free leech decisions of the other players
+        engine.autoMove() || engine.moveAI();
+      if (!progressed) {
+        // a bot played itself into a dead end and was dropped: auto-pass it
+        expect(engine.autoMove(undefined, { autoPass: true }), "game is stuck").to.be.true;
+      }
+      moves++;
+    }
+
+    expect(engine.ended).to.be.true;
+    expect(engine.players.map((pl) => pl.data.victoryPoints)).to.satisfy((scores: number[]) =>
+      scores.every((score) => score >= 0)
+    );
+  });
+
+  it("should play identical games when replaying the same seed", function () {
+    this.timeout(60000);
+
+    const playGame = () => {
+      const engine = new Engine(["init 2 randomSeed"]);
+      let moves = 0;
+      while (!engine.ended && moves < 2000) {
+        const progressed = engine.autoMove() || engine.moveAI() || engine.autoMove(undefined, { autoPass: true });
+        expect(progressed, "game is stuck").to.be.true;
+        moves++;
+      }
+      return engine.moveHistory;
+    };
+
+    expect(playGame()).to.deep.equal(playGame());
+  });
+});

--- a/engine/src/move/ai.ts
+++ b/engine/src/move/ai.ts
@@ -1,0 +1,285 @@
+import seedrandom from "seedrandom";
+import {
+  AvailableBuilding,
+  AvailableCommand,
+  AvailableFreeAction,
+  AvailableMoveShipData,
+  AvailableShipAction,
+  Offer,
+  PossibleBid,
+  ShipAction,
+  TradingLocation,
+} from "../available/types";
+import Engine from "../engine";
+import { Command, Player as PlayerEnum } from "../enums";
+import { AvailableSetupOption } from "../setup";
+
+/**
+ * Deterministic PRNG for bot moves.
+ *
+ * Seeded from the game seed (extracted from the `init` move, so it survives
+ * serialization) and the current position in the move history. Bot moves are
+ * recorded in the move history like any other move, and regular moves do not
+ * use this PRNG, so replaying a game produces the same bot choices.
+ *
+ * `salt` differentiates successive attempts when a random move turns out to be
+ * a dead end.
+ */
+function rngOf(engine: Engine, salt = 0): () => number {
+  const init = engine.moveHistory[0] ?? "";
+  const seed = /^init \d+ (.+)$/.exec(init)?.[1] ?? "bot";
+  return seedrandom(`${seed}:${engine.moveHistory.length}:${salt}`);
+}
+
+/**
+ * Pick a random element of an array.
+ */
+function pick<T>(rng: () => number, arr: T[]): T {
+  return arr[Math.floor(rng() * arr.length)];
+}
+
+/** Commands that don't end the turn on their own (free actions / no-op) */
+const freeCommands = [Command.Spend, Command.BurnPower, Command.EndTurn];
+
+/**
+ * Generate a random legal move for the given player ("dumb AF" bot for UI testing,
+ * not a real AI).
+ *
+ * The returned move only uses commands & arguments advertised by the engine's
+ * available commands, so it is always legal.
+ */
+export function moveAI(engine: Engine, player: PlayerEnum, salt = 0): string {
+  const commands = engine
+    .generateAvailableCommandsIfNeeded()
+    .filter((cmd) => cmd.player === player && cmd.name !== Command.DeadEnd);
+
+  const find = <C extends Command>(command: C) =>
+    commands.find((cmd) => cmd.name === command) as AvailableCommand<C> | undefined;
+
+  const rng = rngOf(engine, salt);
+  const randomOffer = (offers: Offer[]) => pick(rng, offers).offer;
+  const randomBuilding = (buildings: AvailableBuilding[]) => {
+    const building = pick(rng, buildings);
+    return `${building.building} ${building.coordinates}`;
+  };
+
+  // Main commands: playing one of them (plus the follow-ups it triggers) is
+  // what ends the player's turn
+  const mainCommands: [Command, (cmd: AvailableCommand) => string][] = [
+    [
+      Command.ChargePower,
+      (cmd: AvailableCommand<Command.ChargePower>) => `${Command.ChargePower} ${randomOffer(cmd.data.offers)}`,
+    ],
+    [Command.Decline, (cmd: AvailableCommand<Command.Decline>) => `${Command.Decline} ${cmd.data.offers[0].offer}`],
+    [
+      Command.ChooseIncome,
+      (cmd: AvailableCommand<Command.ChooseIncome>) => `${Command.ChooseIncome} ${pick(rng, cmd.data)}`,
+    ],
+    [
+      Command.BrainStone,
+      (cmd: AvailableCommand<Command.BrainStone>) => `${Command.BrainStone} ${pick(rng, cmd.data.choices).area}`,
+    ],
+    [Command.Setup, (cmd: AvailableCommand<Command.Setup>) => randomSetupOption(rng, cmd.data)],
+    [Command.RotateSectors, () => Command.RotateSectors],
+    [
+      Command.ChooseFaction,
+      (cmd: AvailableCommand<Command.ChooseFaction>) => `${Command.ChooseFaction} ${pick(rng, cmd.data)}`,
+    ],
+    [Command.Bid, (cmd: AvailableCommand<Command.Bid>) => randomBid(rng, cmd.data.bids)],
+    [Command.Build, (cmd: AvailableCommand<Command.Build>) => `${Command.Build} ${randomBuilding(cmd.data.buildings)}`],
+    [
+      Command.PISwap,
+      (cmd: AvailableCommand<Command.PISwap>) => `${Command.PISwap} ${randomBuilding(cmd.data.buildings)}`,
+    ],
+    [
+      Command.PlaceLostPlanet,
+      (cmd: AvailableCommand<Command.PlaceLostPlanet>) =>
+        `${Command.PlaceLostPlanet} ${pick(rng, cmd.data.spaces).coordinates}`,
+    ],
+    [Command.MoveShip, (cmd: AvailableCommand<Command.MoveShip>) => randomShipMove(rng, cmd.data)],
+    [
+      Command.Special,
+      (cmd: AvailableCommand<Command.Special>) => `${Command.Special} ${pick(rng, cmd.data.specialacts).income}`,
+    ],
+    [
+      Command.Action,
+      (cmd: AvailableCommand<Command.Action>) => `${Command.Action} ${pick(rng, cmd.data.poweracts).name}`,
+    ],
+    [
+      Command.UpgradeResearch,
+      (cmd: AvailableCommand<Command.UpgradeResearch>) =>
+        `${Command.UpgradeResearch} ${pick(rng, cmd.data.tracks).field}`,
+    ],
+    [
+      Command.ChooseTechTile,
+      (cmd: AvailableCommand<Command.ChooseTechTile>) => `${Command.ChooseTechTile} ${pick(rng, cmd.data.tiles).pos}`,
+    ],
+    [
+      Command.ChooseCoverTechTile,
+      (cmd: AvailableCommand<Command.ChooseCoverTechTile>) =>
+        `${Command.ChooseCoverTechTile} ${pick(rng, cmd.data.tiles).pos}`,
+    ],
+    [
+      Command.FormFederation,
+      (cmd: AvailableCommand<Command.FormFederation>) =>
+        cmd.data.federations.length > 0
+          ? `${Command.FormFederation} ${pick(rng, cmd.data.federations).hexes} ${pick(rng, cmd.data.tiles)}`
+          : null,
+    ],
+    [
+      Command.ChooseFederationTile,
+      (cmd: AvailableCommand<Command.ChooseFederationTile>) =>
+        `${Command.ChooseFederationTile} ${pick(rng, cmd.data.tiles)}`,
+    ],
+    [Command.Pass, (cmd: AvailableCommand<Command.Pass>) => `${Command.Pass} ${pick(rng, cmd.data.boosters)}`],
+    [
+      Command.ChooseRoundBooster,
+      (cmd: AvailableCommand<Command.ChooseRoundBooster>) =>
+        `${Command.ChooseRoundBooster} ${pick(rng, cmd.data.boosters)}`,
+    ],
+  ];
+
+  for (const [command, handler] of mainCommands) {
+    const cmd = find(command);
+    if (cmd) {
+      const move = handler(cmd);
+      if (move) {
+        return `${playerPrefix(engine, player)} ${move}`;
+      }
+    }
+  }
+
+  // Free commands: they don't end the turn on their own, add an endturn so the
+  // move is complete
+  for (const command of freeCommands) {
+    const cmd = find(command);
+    if (cmd) {
+      return `${playerPrefix(engine, player)} ${freeCommandMove(rng, cmd)}. ${Command.EndTurn}`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Generate a random command to append to the ongoing turn, without a player
+ * prefix. Used to complete a turn once a move has already been started.
+ */
+export function appendCommand(engine: Engine, player: PlayerEnum, salt = 0): string {
+  const commands = engine
+    .generateAvailableCommandsIfNeeded()
+    .filter((cmd) => cmd.player === player && cmd.name !== Command.DeadEnd);
+
+  const rng = rngOf(engine, salt);
+  const find = <C extends Command>(command: C) =>
+    commands.find((cmd) => cmd.name === command) as AvailableCommand<C> | undefined;
+
+  // Follow-up decisions triggered by the previous command(s) of the turn
+  const techTile = find(Command.ChooseTechTile);
+  if (techTile) {
+    return `${Command.ChooseTechTile} ${pick(rng, techTile.data.tiles).pos}`;
+  }
+
+  const coverTechTile = find(Command.ChooseCoverTechTile);
+  if (coverTechTile) {
+    return `${Command.ChooseCoverTechTile} ${pick(rng, coverTechTile.data.tiles).pos}`;
+  }
+
+  const upgradeResearch = find(Command.UpgradeResearch);
+  if (upgradeResearch) {
+    return `${Command.UpgradeResearch} ${pick(rng, upgradeResearch.data.tracks).field}`;
+  }
+
+  const federationTile = find(Command.ChooseFederationTile);
+  if (federationTile) {
+    return `${Command.ChooseFederationTile} ${pick(rng, federationTile.data.tiles)}`;
+  }
+
+  const build = find(Command.Build);
+  if (build) {
+    const building = pick(rng, build.data.buildings);
+    return `${Command.Build} ${building.building} ${building.coordinates}`;
+  }
+
+  const lostPlanet = find(Command.PlaceLostPlanet);
+  if (lostPlanet) {
+    return `${Command.PlaceLostPlanet} ${pick(rng, lostPlanet.data.spaces).coordinates}`;
+  }
+
+  const brainstone = find(Command.BrainStone);
+  if (brainstone) {
+    return `${Command.BrainStone} ${pick(rng, brainstone.data.choices).area}`;
+  }
+
+  // Free commands (spend / burn), to be able to afford the follow-ups above
+  for (const command of [Command.Spend, Command.BurnPower] as const) {
+    const cmd = find(command);
+    if (cmd) {
+      return freeCommandMove(rng, cmd);
+    }
+  }
+
+  if (find(Command.EndTurn)) {
+    return Command.EndTurn;
+  }
+
+  return null;
+}
+
+function playerPrefix(engine: Engine, player: PlayerEnum): string {
+  return engine.player(player)?.faction ?? `p${player + 1}`;
+}
+
+function randomSetupOption(rng: () => number, cmd: AvailableSetupOption): string {
+  return `${Command.Setup} ${cmd.type} ${cmd.position} to ${pick(rng, cmd.options)}`;
+}
+
+function randomBid(rng: () => number, bids: PossibleBid[]): string {
+  const bid = pick(rng, bids);
+  return `${Command.Bid} ${bid.faction} ${pick(rng, bid.bid)}`;
+}
+
+function randomFreeAction(rng: () => number, acts: AvailableFreeAction[]): string {
+  const act = pick(
+    rng,
+    acts.filter((a) => !a.hide)
+  );
+  return `${act.cost} for ${act.income}`;
+}
+
+function randomShipMove(rng: () => number, data: AvailableMoveShipData[]): string {
+  const ship = pick(rng, data);
+  const target = pick(rng, ship.targets);
+  const action = randomShipAction(rng, target.actions);
+
+  return `${Command.MoveShip} ${ship.ship} ${ship.source} ${target.location.coordinates}${action}`;
+}
+
+function randomShipAction(rng: () => number, actions: AvailableShipAction[]): string {
+  const choices = (actions ?? []).filter((action) => action.type !== ShipAction.Nothing && action.locations.length > 0);
+
+  if (choices.length === 0) {
+    return "";
+  }
+
+  const action = pick(rng, choices);
+  const location = pick(rng, action.locations);
+
+  // `cost` contains the satellite cost for trading locations near other players'
+  // structures, it is not part of the command
+  const tradeCost = (location as TradingLocation).tradeCost;
+  const cost = tradeCost ? ` ${tradeCost}` : "";
+
+  return ` ${action.type} ${location.coordinates}${cost}`;
+}
+
+function freeCommandMove(rng: () => number, cmd: AvailableCommand): string {
+  switch (cmd.name) {
+    case Command.Spend:
+      return `${Command.Spend} ${randomFreeAction(rng, (cmd as AvailableCommand<Command.Spend>).data.acts)}`;
+    case Command.BurnPower:
+      return `${Command.BurnPower} ${pick(rng, (cmd as AvailableCommand<Command.BurnPower>).data)}`;
+    default:
+      return Command.EndTurn;
+  }
+}

--- a/engine/wrapper.spec.ts
+++ b/engine/wrapper.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { PlayerEnum } from ".";
 import Beta2 from "./fixtures/Beta-2.json";
 import Engine from "./src/engine";
-import { automove, move, replay, setPlayerSettings } from "./wrapper";
+import { automove, move, moveAI, replay, setPlayerSettings, toSave } from "./wrapper";
 
 describe("wrapper", () => {
   describe("automove", () => {
@@ -142,6 +142,67 @@ describe("wrapper", () => {
   describe("replay", () => {
     it("should replay a game with beta variants", () => {
       expect(() => replay(Engine.fromData(Beta2))).to.not.throw();
+    });
+  });
+
+  describe("moveAI", () => {
+    it("should make a move for the current player, given serialized data", () => {
+      const engine = new Engine(["init 2 randomSeed"]);
+      engine.generateAvailableCommandsIfNeeded();
+
+      const data = JSON.parse(JSON.stringify(engine));
+      const newEngine = moveAI(data, 0);
+
+      expect(newEngine.moveHistory.length).to.equal(2);
+      expect(newEngine.playerToMove).to.equal(1);
+    });
+
+    it("should return a saveable state", () => {
+      const engine = new Engine(["init 2 randomSeed"]);
+      engine.generateAvailableCommandsIfNeeded();
+
+      const newEngine = moveAI(JSON.parse(JSON.stringify(engine)), 0);
+
+      expect(toSave(newEngine)).to.not.equal(undefined);
+    });
+
+    it("should do nothing when it is not the player's turn", () => {
+      const engine = new Engine(["init 2 randomSeed"]);
+      engine.generateAvailableCommandsIfNeeded();
+
+      const newEngine = moveAI(JSON.parse(JSON.stringify(engine)), 1);
+
+      expect(newEngine.moveHistory.length).to.equal(1);
+    });
+
+    it("should let bots play a full game through the wrapper", function () {
+      this.timeout(60000);
+
+      let engine = new Engine(["init 2 randomSeed"]);
+
+      // like on the platform, players have auto-charge settings
+      for (let player = 0; player < engine.players.length; player++) {
+        engine = setPlayerSettings(engine, player, { autoCharge: "1" });
+      }
+      engine.generateAvailableCommandsIfNeeded();
+
+      let moves = 0;
+      while (!engine.ended && moves < 2000) {
+        const historyLength = engine.moveHistory.length;
+
+        // the platform hands the wrapper serialized data
+        engine = moveAI(JSON.parse(JSON.stringify(engine)), engine.playerToMove);
+
+        if (engine.moveHistory.length === historyLength) {
+          // the current player cannot move: it played itself into a dead end.
+          // On the platform it would be dropped by the other players
+          engine.players[engine.playerToMove].dropped = true;
+          automove(engine);
+        }
+        moves++;
+      }
+
+      expect(engine.ended).to.be.true;
     });
   });
 });

--- a/engine/wrapper.ts
+++ b/engine/wrapper.ts
@@ -185,6 +185,28 @@ export async function replay(engine: Engine, { to = Infinity } = { to: Infinity 
   return engine;
 }
 
+export function moveAI(engine: Engine, player: number) {
+  if (!(engine instanceof Engine)) {
+    engine = Engine.fromData(engine);
+  }
+
+  if (engine.ended || engine.playerToMove !== player) {
+    return engine;
+  }
+
+  const round = engine.round;
+
+  if (engine.moveAI()) {
+    afterMove(engine, round);
+    engine.generateAvailableCommandsIfNeeded();
+    // resolve forced / trivial decisions (free leech, income, ...) so the game
+    // can advance to the next bot move
+    automove(engine);
+  }
+
+  return engine;
+}
+
 export async function dropPlayer(engine: Engine, player: number) {
   engine = engine instanceof Engine ? engine : Engine.fromData(engine);
 


### PR DESCRIPTION
## What

Adds a `moveAI` capability so the Boardgamers platform can drive "dumb AF" bot players (for UI testing, not a real AI).

The engine is class-based, so this exposes both:
- `Engine.moveAI(): boolean` — makes a legal move for `engine.playerToMove`.
- A standalone `moveAI(engine, player, salt?)` generator in `engine/src/move/ai.ts`, re-exported from `engine/index.ts`.
- A platform-facing `moveAI(engine, player)` in `engine/wrapper.ts` (the functional wrapper the platform adapts), so `engineRunner.call(..., "moveAI", [data, player])` works like the other engines.

## How it works

- For the current player, it enumerates the engine's `availableCommands` and builds a random **legal** move string from them (all command types: build, faction, bid, charge/decline, tech tiles, research, federations, pass, ships, setup, …).
- **Deterministic:** randomness comes from a PRNG seeded by the game's `init` seed + position in the move history, so replays of bot games stay identical. No `Math.random`.
- **Multi-step turns:** a command can trigger follow-up decisions (tech tile after a lab, income choices, …). The bot builds the whole turn as a single dot-separated move — the engine's one mechanism for several commands in a turn — simulating on a throwaway copy and only committing once the turn actually completes.
- **Dead ends:** a purely random move can be a legal dead end (e.g. upgrading your last mine with no ore left to rebuild, which the engine offers no way out of — see #76). Such attempts are detected during simulation, retried with a different random draw, and if nothing works `moveAI` returns `false` leaving the engine unchanged (the platform then leaves the bot stuck / droppable rather than wedging the game).
- After a bot move, the wrapper runs `automove` so other players' forced/trivial decisions (free leech, income, …) resolve and the game advances.

## Tests

- `engine/src/move/ai.spec.ts` (7 tests): legal move generation, no-op when no player to move, determinism for a seed, completing the setup phase, a **bot-only game playing to the end**, and identical replays of the same seed.
- `engine/wrapper.spec.ts` `moveAI` block (4 tests): the platform contract — `moveAI(serializedData, player)` makes a move, returns a saveable state, no-ops off-turn, and a bot-only game completes through the wrapper.

Full engine suite: **280 passing**. `tsc --noEmit` and `eslint` are clean.

> Note: `tsc`/`prettier` against the repo's pinned configs are broken in this sandbox for unrelated, pre-existing reasons (TS 3.9 can't parse the hoisted `@types/lodash@4.17`; the root `prettier-plugin-organize-imports` mismatches the hoisted TS 4.9). Verified on `master` too. I type-checked with the compatible `@types/lodash` and formatted with the repo's prettier settings directly.
